### PR TITLE
Fail CMake if pymake is not found

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,6 +9,9 @@ SET(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR}/run)
 execute_process(
     COMMAND pymake -v success -p ${CMAKE_SOURCE_DIR}
 )
+if(ret EQUAL "1")
+    message(FATAL_ERROR "Could not run pymake; Have you run `sudo pip install generate-cmake`?")
+endif()
 
 set(CMAKE_CXX_COMPILER "g++-7")
 set(CMAKE_CXX_FLAGS "--std=c++17 -g -O1 -fno-omit-frame-pointer -Wall -Wno-deprecated-declarations ${CMAKE_CXX_FLAGS}")


### PR DESCRIPTION
This commit also removes the `x` permission from the top-level CMakeLists.txt, which is currently executable.