### PR TITLE
Adding initial build / deploy scripts

### DIFF
--- a/infrastructure/scripts/docker/Dockerfile
+++ b/infrastructure/scripts/docker/Dockerfile
@@ -1,0 +1,100 @@
+FROM ubuntu:bionic
+
+#
+# Install devtools
+#
+
+RUN apt update
+RUN apt install software-properties-common -y
+RUN add-apt-repository ppa:ubuntu-toolchain-r/test -y
+RUN apt install build-essential -y
+RUN apt update
+
+RUN apt install git -y
+RUN apt install cmake gcc-7 g++-7 -y
+
+RUN apt install libgtest-dev -y
+RUN cd /usr/src/gtest; cmake CMakeLists.txt; make; cp *.a /usr/lib
+
+
+#
+# Libs
+#
+
+RUN apt install libxmu-dev libxi-dev -y
+RUN apt install libassimp-dev -y
+RUN apt install libyaml-cpp-dev -y
+RUN DEBIAN_FRONTEND=noninteractive apt-get install -y tzdata
+RUN apt install libopencv-dev python-opencv -y
+RUN apt install libssl-dev -y
+
+
+#
+# Python
+#
+
+RUN apt install python-pip ipython -y
+RUN pip install --upgrade pip
+RUN pip install matplotlib
+RUN pip install colorama
+RUN pip install generate-cmake 
+RUN apt install python-tk -y
+
+
+#
+# Gl Viewer Support
+#
+
+RUN apt install xorg-dev libglu1-mesa-dev -y
+RUN apt install libglfw3 libglfw3-dev libglew-dev -y
+RUN apt install freeglut3-dev -y
+
+
+#
+# xvfb for x-fowarding while running headless (on a mac, server, or vehicle node)
+#
+
+RUN apt install -y xvfb
+ADD support/xvfb.init /etc/init.d/xvfb
+RUN chmod +x /etc/init.d/xvfb
+RUN update-rc.d xvfb defaults
+CMD (service xvfb start; export DISPLAY=:10;)
+
+
+#
+# Capnproto
+#
+
+RUN apt install autoconf libtool -y
+RUN git clone https://github.com/sandstorm-io/capnproto.git; cd capnproto/c++; autoreconf -i; ./configure; make -j6 check; make install
+RUN rm -r capnproto
+
+
+#
+# Mosquitto
+#
+RUN apt install mosquitto mosquitto-clients -y
+
+
+#
+# paho.mqtt.cpp
+#
+RUN apt install doxygen graphviz -y
+RUN git clone https://github.com/eclipse/paho.mqtt.c.git; cd paho.mqtt.c; git checkout v1.2.1; cmake -Bbuild -H. -DPAHO_WITH_SSL=ON; cmake --build build/ --target install; ldconfig
+RUN rm -r paho.mqtt.c
+RUN git clone https://github.com/eclipse/paho.mqtt.cpp; cd paho.mqtt.cpp; cmake -Bbuild -H. -DPAHO_BUILD_DOCUMENTATION=TRUE -DPAHO_BUILD_SAMPLES=TRUE; cmake --build build/ --target install
+RUN rm -r paho.mqtt.cpp
+
+
+#
+# X tests (xeyes, glxgears, etc.)
+#
+
+RUN apt install mesa-utils x11-apps -y
+
+
+#
+# Webcam tests (ex. fswebcam --save test.jpeg; eog test.jpeg)
+#
+
+RUN apt install fswebcam eog -y

--- a/infrastructure/scripts/docker/support/xvfb.init
+++ b/infrastructure/scripts/docker/support/xvfb.init
@@ -1,0 +1,45 @@
+#!/bin/bash
+#
+# /etc/rc.d/init.d/xvfbd
+#
+# chkconfig: 345 95 28
+# description: Starts/Stops X Virtual Framebuffer server
+# processname: Xvfb
+#
+
+
+[ "${NETWORKING}" = "no" ] && exit 0
+
+PROG="/usr/bin/Xvfb"
+PROG_OPTIONS=":10 -ac"
+PROG_OUTPUT="/tmp/Xvfb.out"
+
+case "$1" in
+    start)
+        echo -n "Starting : X Virtual Frame Buffer "
+        $PROG $PROG_OPTIONS>>$PROG_OUTPUT 2>&1 &
+        disown -ar
+        ;;
+    stop)
+        echo -n "Shutting down : X Virtual Frame Buffer"
+        killproc $PROG
+        RETVAL=$?
+        [ $RETVAL -eq 0 ] && /bin/rm -f /var/lock/subsys/Xvfb
+ /var/run/Xvfb.pid
+        echo
+        ;;
+    restart|reload)
+        $0 stop
+        $0 start
+        RETVAL=$?
+        ;;
+    status)
+        status Xvfb
+        RETVAL=$?
+        ;;
+    *)
+     echo $"Usage: $0 (start|stop|restart|reload|status)"
+     exit 1
+esac
+
+exit $RETVAL

--- a/infrastructure/scripts/environment_bootstrap.sh
+++ b/infrastructure/scripts/environment_bootstrap.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+
+echo "export PATH=\$PATH:"$DIR >> ~/.bashrc

--- a/infrastructure/scripts/jet
+++ b/infrastructure/scripts/jet
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+case "$1" in
+"run")
+    jet_run.sh "${@:2}"
+    ;;
+"build")
+    jet_build.sh "${@:2}"
+    ;;
+"image")
+	jet_image.sh "${@:2}"
+	;;
+"deploy")
+	jet_deploy.sh "${@:2}"
+	;;
+*)
+    echo "Unknown option '$1': jet modes are [run|build|image]"
+    ;;
+esac

--- a/infrastructure/scripts/jet_build.sh
+++ b/infrastructure/scripts/jet_build.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+echo "jet build not yet implemented."

--- a/infrastructure/scripts/jet_deploy.sh
+++ b/infrastructure/scripts/jet_deploy.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+echo "jet deploy not yet implemented."

--- a/infrastructure/scripts/jet_image.sh
+++ b/infrastructure/scripts/jet_image.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+JET_REPO_PATH=$(git rev-parse --show-toplevel)
+
+if [ $? -ne 0 ]; then
+    exit $?
+fi
+
+DATE=`date +%Y.%m.%d-%H.%M.%S`
+
+echo Building image: hoverjet/jet:$DATE
+docker build $JET_REPO_PATH/infrastructure/scripts/docker/ -t hoverjet/jet:$DATE

--- a/infrastructure/scripts/jet_run.sh
+++ b/infrastructure/scripts/jet_run.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+JET_REPO_PATH=$(git rev-parse --show-toplevel)
+
+if [ $? -ne 0 ]; then
+    exit $?
+fi
+
+xhost +
+
+CONTAINER_ID=$(docker run -it -d -v $JET_REPO_PATH:/jet -v /tmp/.X11-unix:/tmp/.X11-unix -e DISPLAY -e NO_AT_BRIDGE=1 --privileged hoverjet/jet bash)
+if [ $? -ne 0 ]; then
+    exit $?
+fi
+
+xauth list | while read line; do docker exec -it $CONTAINER_ID xauth add $line; if [ $? -ne 0 ]; then
+    echo '"^ Not actually an error" - Ben'
+fi; done
+
+docker exec -it $CONTAINER_ID bash
+
+docker stop $CONTAINER_ID


### PR DESCRIPTION
`jet image`: Creates a new docker image based on the Dockerfile in the repo
`jet run`: Starts a new container from hoverjet/jet:latest, then runs bash inside of it. In the future, this will allow users to pass in commands other than bash. 
`jet build`: Not implemented yet. Once the build system is more stable, this will start up a container and launch the software build process within it.
`jet deploy`: Not implemented yet, but will push binaries from the local machine to the vehicle, then will run the onboard software.