### PR TITLE
Build + Run scripts now detect CPU architecture

### DIFF
--- a/infrastructure/scripts/docker/Dockerfile
+++ b/infrastructure/scripts/docker/Dockerfile
@@ -27,7 +27,7 @@ RUN apt install libyaml-cpp-dev -y
 RUN DEBIAN_FRONTEND=noninteractive apt-get install -y tzdata
 RUN apt install libopencv-dev python-opencv -y
 RUN apt install libssl-dev -y
-
+RUN apt install libreadline6-dev -y
 
 #
 # Python
@@ -35,6 +35,7 @@ RUN apt install libssl-dev -y
 
 RUN apt install python-pip ipython -y
 RUN pip install --upgrade pip
+RUN apt install libfreetype6-dev -y
 RUN pip install matplotlib
 RUN pip install colorama
 RUN pip install generate-cmake 

--- a/infrastructure/scripts/jet_image.sh
+++ b/infrastructure/scripts/jet_image.sh
@@ -6,7 +6,17 @@ if [ $? -ne 0 ]; then
     exit $?
 fi
 
+CPU_INFO=$(lscpu)
+if [[ $(echo $CPU_INFO | grep "Architecture:") =~ "x86_64" ]]; then
+    IMAGE_NAME="jet"
+fi
+if [[ $(echo $CPU_INFO | grep "Architecture:") =~ "arm" ]]; then
+    IMAGE_NAME="jet-arm"
+fi
+
 DATE=`date +%Y.%m.%d-%H.%M.%S`
 
-echo Building image: hoverjet/jet:$DATE
-docker build $JET_REPO_PATH/infrastructure/scripts/docker/ -t hoverjet/jet:$DATE
+FULL_IMAGE_NAME_TAG="hoverjet/$IMAGE_NAME:$DATE"
+
+echo Building image: $FULL_IMAGE_NAME_TAG
+docker build $JET_REPO_PATH/infrastructure/scripts/docker/ -t $FULL_IMAGE_NAME_TAG

--- a/infrastructure/scripts/jet_run.sh
+++ b/infrastructure/scripts/jet_run.sh
@@ -6,9 +6,18 @@ if [ $? -ne 0 ]; then
     exit $?
 fi
 
+CPU_INFO=$(lscpu)
+if [[ $(echo $CPU_INFO | grep "Architecture:") =~ "x86_64" ]]; then
+    IMAGE_NAME="jet"
+fi
+if [[ $(echo $CPU_INFO | grep "Architecture:") =~ "arm" ]]; then
+    IMAGE_NAME="jet-arm"
+fi
+FULL_IMAGE_NAME=hoverjet/$IMAGE_NAME
+
 xhost +
 
-CONTAINER_ID=$(docker run -it -d -v $JET_REPO_PATH:/jet -v /tmp/.X11-unix:/tmp/.X11-unix -e DISPLAY -e NO_AT_BRIDGE=1 --privileged hoverjet/jet bash)
+CONTAINER_ID=$(docker run -it -d -v $JET_REPO_PATH:/jet -v /tmp/.X11-unix:/tmp/.X11-unix -e DISPLAY -e NO_AT_BRIDGE=1 --net=host --privileged $FULL_IMAGE_NAME bash)
 if [ $? -ne 0 ]; then
     exit $?
 fi


### PR DESCRIPTION
We have now have two separate docker repos:
- `hoverjet/jet`: for x86 images
- `hoverjet/jet-arm`: for ARM images

The scripts had the dockerhub repo name `hoverjet/jet` hardcoded in earlier, but now that we're running on both architectures, we need the scripts to decide which image to run. The scripts now check the architecture of the host CPU, then select either `jet` or `jet-arm`. 

In the future we'll need to update this logic to handle the case where the script is running on a dev machine but starting a container on an ARM board.