### PR TITLE
Improvements to `jet` scripts

### DIFF
--- a/infrastructure/scripts/jet
+++ b/infrastructure/scripts/jet
@@ -1,5 +1,33 @@
 #!/bin/bash
 
+function help () {
+cat <<-END
+Usage: jet COMMAND
+
+Builds a new jet docker image for your host's architecture.
+
+-h| --help           Show this message
+
+commands:
+build                Build the jet code
+image                Build a new jet docker image
+run                  Run an executable inside of a docker container
+deploy               Run jet software on a vehicle or bench
+END
+}
+
+while [ -n "$1" ]; do
+    case "$1" in
+        -h | --help)
+            help
+            exit
+            ;;
+        *)
+            break
+            ;;
+    esac
+done
+
 case "$1" in
 "run")
     jet_run.sh "${@:2}"
@@ -14,6 +42,7 @@ case "$1" in
 	jet_deploy.sh "${@:2}"
 	;;
 *)
-    echo "Unknown option '$1': jet modes are [run|build|image]"
+    echo "Unknown option '$1': jet modes are [run|build|image|deploy]"
+    help
     ;;
 esac

--- a/infrastructure/scripts/jet_build.sh
+++ b/infrastructure/scripts/jet_build.sh
@@ -1,5 +1,27 @@
 #!/bin/bash
 
+function help () {
+cat <<-END
+Usage: jet build
+
+Builds the jet project.
+
+-h| --help           Show this message
+END
+}
+
+while [ -n "$1" ]; do
+    case "$1" in
+        -h | --help)
+            help
+            exit
+            ;;
+        *)
+            break
+            ;;
+    esac
+done
+
 JET_REPO_PATH=$(git rev-parse --show-toplevel)
 
 if [ $? -ne 0 ]; then

--- a/infrastructure/scripts/jet_image.sh
+++ b/infrastructure/scripts/jet_image.sh
@@ -1,5 +1,45 @@
 #!/bin/bash
 
+function help () {
+cat <<-END
+Usage: jet build
+
+Builds a new jet docker image for your host's architecture.
+
+-h| --help           Show this message
+-p| --push           Push this image to dockerhub on build completion
+--latest             Tag the image as "latest" on build completion
+--no-cache           Run a clean build of the image, reperforming every cached step
+END
+}
+
+PUSH=0
+LATEST=0
+
+while test $# -gt 0; do
+        case "$1" in
+                -h|--help)
+                        help
+                        exit 0
+                        ;;
+                -p|--push*)
+                        PUSH=1
+                        shift
+                        ;;
+                --latest*)
+                        LATEST=1
+                        shift
+                        ;;
+                --no-cache*)
+                        NO_CACHE="--no-cache"
+                        shift
+                        ;;
+                *)
+                        break
+                        ;;
+        esac
+done
+
 JET_REPO_PATH=$(git rev-parse --show-toplevel)
 
 if [ $? -ne 0 ]; then
@@ -19,4 +59,19 @@ DATE=`date +%Y.%m.%d-%H.%M.%S`
 FULL_IMAGE_NAME_TAG="hoverjet/$IMAGE_NAME:$DATE"
 
 echo Building image: $FULL_IMAGE_NAME_TAG
-docker build $JET_REPO_PATH/infrastructure/scripts/docker/ -t $FULL_IMAGE_NAME_TAG
+docker build $NO_CACHE $JET_REPO_PATH/infrastructure/scripts/docker/ -t $FULL_IMAGE_NAME_TAG
+
+if [[ $LATEST -ne 0 ]]; then
+	LATEST_IMAGE_NAME_TAG="hoverjet/$IMAGE_NAME:latest"
+	echo "Tagging $FULL_IMAGE_NAME_TAG as latest."
+	docker tag $FULL_IMAGE_NAME_TAG $LATEST_IMAGE_NAME_TAG
+fi
+
+if [[ $PUSH -ne 0 ]]; then
+	echo "Pushing $FULL_IMAGE_NAME_TAG"
+	docker push $FULL_IMAGE_NAME_TAG
+	if [[ $LATEST -ne 0 ]]; then
+		echo "Pushing $LATEST_IMAGE_NAME_TAG"
+		docker push $LATEST_IMAGE_NAME_TAG
+	fi
+fi

--- a/infrastructure/scripts/jet_run.sh
+++ b/infrastructure/scripts/jet_run.sh
@@ -1,5 +1,27 @@
 #!/bin/bash
 
+function help () {
+cat <<-END
+Usage: jet run COMMAND
+
+Starts a docker container from the jet image, then executes the specified command inside of it. If no command is specified, bash will be run.
+
+-h| --help           Show this message
+END
+}
+
+while [ -n "$1" ]; do
+    case "$1" in
+        -h | --help)
+            help
+            exit
+            ;;
+        *)
+            break
+            ;;
+    esac
+done
+
 JET_REPO_PATH=$(git rev-parse --show-toplevel)
 
 if [ $? -ne 0 ]; then
@@ -26,6 +48,13 @@ xauth list | while read line; do docker exec -it $CONTAINER_ID xauth add $line; 
     echo '"^ Not actually an error" - Ben'
 fi; done
 
-docker exec -it $CONTAINER_ID bash
+if [ -z "${@:1}" ]
+then
+    docker exec -it $CONTAINER_ID bash
+else
+    COMMAND="${@:1}"
+    echo "Running command \"$COMMAND\" in container."
+    docker exec -it $CONTAINER_ID bash -c "$COMMAND"
+fi
 
 docker stop $CONTAINER_ID


### PR DESCRIPTION
1. `jet run` can now execute arbitrary commands passed into it (ie. `jet run ./run/camera_test`)
2. `jet image` now allows you to push the image automatically  with `jet image --push` and allows you to tag your new image as latest with `jet image --latest`. You can also push the image with latest tag by running `jet image --push --latest`
3. `jet image` has a `--no-cache` option, which forces a clean image build
4. Added `--help` options to all scripts