### PR TITLE
jet build is now parallel and users can specify targets

### DIFF
--- a/infrastructure/scripts/jet_build.sh
+++ b/infrastructure/scripts/jet_build.sh
@@ -31,13 +31,17 @@ fi
 CPU_INFO=$(lscpu)
 if [[ $(echo $CPU_INFO | grep "Architecture:") =~ "x86_64" ]]; then
     IMAGE_NAME="jet"
+    J_NUM=12
 fi
 if [[ $(echo $CPU_INFO | grep "Architecture:") =~ "arm" ]]; then
     IMAGE_NAME="jet-arm"
+    J_NUM="3"
 fi
 FULL_IMAGE_NAME=hoverjet/$IMAGE_NAME
 
-docker run -it -v $JET_REPO_PATH:/jet --net=host --privileged $FULL_IMAGE_NAME bash -c "cd /jet; cmake .; make;"
+TARGETS="${@:1}"
+
+docker run -it -v $JET_REPO_PATH:/jet --net=host --privileged $FULL_IMAGE_NAME bash -c "cd /jet; cmake .; make -j $J_NUM $TARGETS;"
 if [ $? -ne 0 ]; then
     exit $?
 fi


### PR DESCRIPTION
1. make now uses flag -j to run build on multiple cores. If build is running on x86, it attempts to use up to 12 cores. If build is running on ARM, it only attempts to run on 3 cores to avoid using all 4 odroid cores during build.
2. You can now specific specific targets to build. Ex: `jet build message`