### PR TITLE
jet run now starts a broker container

### DIFF
--- a/infrastructure/scripts/jet
+++ b/infrastructure/scripts/jet
@@ -13,6 +13,7 @@ build                Build the jet code
 image                Build a new jet docker image
 run                  Run an executable inside of a docker container
 deploy               Run jet software on a vehicle or bench
+broker               Configure the IPC Broker on this host
 END
 }
 
@@ -41,8 +42,11 @@ case "$1" in
 "deploy")
 	jet_deploy.sh "${@:2}"
 	;;
+"broker")
+    jet_broker.sh "${@:2}"
+    ;;
 *)
-    echo "Unknown option '$1': jet modes are [run|build|image|deploy]"
+    echo "Unknown option '$1': jet modes are [run|build|image|deploy|broker]"
     help
     ;;
 esac

--- a/infrastructure/scripts/jet_broker.sh
+++ b/infrastructure/scripts/jet_broker.sh
@@ -1,0 +1,67 @@
+#!/bin/bash
+
+function help () {
+cat <<-END
+Usage: jet build
+
+Starts up a new IPC Broker container. If one is already running, does nothing.
+
+-h| --help           Show this message
+-f| --force          Force restart of IPC Broker container
+END
+}
+
+CONTAINER_NAME=IPCBroker
+
+FORCE_RESTART=0
+IPC_BROKER_IS_RUNNING=0
+START=1
+
+while test $# -gt 0; do
+        case "$1" in
+                -h|--help)
+                        help
+                        exit 0
+                        ;;
+                -f|--force*)
+                        FORCE_RESTART=1
+                        shift
+                        ;;
+                *)
+                        break
+                        ;;
+        esac
+done
+
+if [[ $(docker ps | grep $CONTAINER_NAME) =~ $CONTAINER_NAME ]]; then
+    IPC_BROKER_IS_RUNNING=1
+    START=0
+fi
+
+if [[ $FORCE_RESTART -ne 0 ]]; then
+    if [[ $IPC_BROKER_IS_RUNNING -ne 0 ]]; then
+        docker stop $CONTAINER_NAME
+        echo "Stopping existing $CONTAINER_NAME container."
+    fi
+    START=1
+fi
+
+
+if [[ $START -ne 0 ]]; then
+    CPU_INFO=$(lscpu)
+    if [[ $(echo $CPU_INFO | grep "Architecture:") =~ "x86_64" ]]; then
+        IMAGE_NAME="jet"
+    fi
+    if [[ $(echo $CPU_INFO | grep "Architecture:") =~ "arm" ]]; then
+        IMAGE_NAME="jet-arm"
+    fi
+    FULL_IMAGE_NAME=hoverjet/$IMAGE_NAME
+
+    UNUSED=$(docker run -d --rm --name $CONTAINER_NAME --net=host --privileged $FULL_IMAGE_NAME mosquitto)
+
+    if [ $? -ne 0 ]; then
+        echo "Failed to start IPCBroker container."
+        exit $?
+    fi
+    echo "Started IPCBroker container."
+fi

--- a/infrastructure/scripts/jet_run.sh
+++ b/infrastructure/scripts/jet_run.sh
@@ -10,20 +10,28 @@ Starts a docker container from the jet image, then executes the specified comman
 END
 }
 
+MQTT_ADDRESS=tcp://localhost:1883
+
 while [ -n "$1" ]; do
     case "$1" in
         -h | --help)
             help
             exit
             ;;
+        -b | --broker)
+                MQTT_ADDRESS=$2
+                shift
+                shift
+                ;;
         *)
             break
             ;;
     esac
 done
 
+jet_broker.sh
+
 JET_REPO_PATH=$(git rev-parse --show-toplevel)
-MQTT_ADDRESS=tcp://localhost:1883
 
 if [ $? -ne 0 ]; then
     exit $?


### PR DESCRIPTION
1. `jet run`now automatically starts the mosquitto container if it's not already running.
2. You can now tell `jet run` to set a remote broker address for BQs