### PR TITLE
Changing Supervisor behavior to SIGINT BQs on stop

### DIFF
--- a/config/supervisor/supervisor.conf
+++ b/config/supervisor/supervisor.conf
@@ -23,6 +23,7 @@ serverurl=unix:///tmp/supervisor.sock
 command=/jet/run/turbine_interface_bq_main
 stderr_logfile = /var/log/supervisord/turbine_interface-stderr.log
 stdout_logfile = /var/log/supervisord/turbine_interface-stdout.log
+stopsignal=INT
 
 [program:logger]
 environment=LOGGED_CHANNELS="force_sensor_output_channel,servo_command_channel,turbine_ignition,turbine_set_throttle,turbine_state,imu",
@@ -30,76 +31,89 @@ environment=LOGGED_CHANNELS="force_sensor_output_channel,servo_command_channel,t
 command=/jet/run/message_logger_bq_main
 stderr_logfile = /var/log/supervisord/logger-stderr.log
 stdout_logfile = /var/log/supervisord/logger-stdout.log
+stopsignal=INT
 
 [program:imu]
 command=/jet/run/imu_balsaq_main
 stderr_logfile = /var/log/supervisord/imu-stderr.log
 stdout_logfile = /var/log/supervisord/imu-stdout.log
+stopsignal=INT
 
 [program:servo_interface]
 command=/jet/run/servo_balsaq_main /jet/embedded/servo_driver/cfg/servo_cfg0.yaml /jet/embedded/servo_driver/cfg/servo_cfg1.yaml /jet/embedded/servo_driver/cfg/servo_cfg2.yaml /jet/embedded/servo_driver/cfg/servo_cfg3.yaml
 stderr_logfile = /var/log/supervisord/servo_interface-stderr.log
 stdout_logfile = /var/log/supervisord/servo_interface-stdout.log
+stopsignal=INT
 
 [program:thrust_stand_test-sine_wave_slow]
 command=/jet/run/thrust_stand_control_test_balsaq_main /jet/sine_wave_slow.yaml
 stderr_logfile = /var/log/supervisord/thrust_stand_test-sine_wave_slow-stderr.log
 stdout_logfile = /var/log/supervisord/thrust_stand_test-sine_wave_slow-stdout.log
 autostart = false
+stopsignal=INT
 
 [program:thrust_stand_test-sine_wave_medium]
 command=/jet/run/thrust_stand_control_test_balsaq_main /jet/sine_wave_medium.yaml
 stderr_logfile = /var/log/supervisord/thrust_stand_test-sine_wave_medium-stderr.log
 stdout_logfile = /var/log/supervisord/thrust_stand_test-sine_wave_medium-stdout.log
 autostart = false
+stopsignal=INT
 
 [program:thrust_stand_test-sine_wave_fast]
 command=/jet/run/thrust_stand_control_test_balsaq_main /jet/sine_wave_fast.yaml
 stderr_logfile = /var/log/supervisord/thrust_stand_test-sine_wave_fast-stderr.log
 stdout_logfile = /var/log/supervisord/thrust_stand_test-sine_wave_fast-stdout.log
 autostart = false
+stopsignal=INT
 
 [program:thrust_stand_test-set_zero]
 command=/jet/run/thrust_stand_control_test_balsaq_main /jet/set_zero.yaml
 stderr_logfile = /var/log/supervisord/thrust_stand_test-set_zero-stderr.log
 stdout_logfile = /var/log/supervisord/thrust_stand_test-set_zero-stdout.log
 autostart = false
+stopsignal=INT
 
 [program:thrust_stand_test-02_antisymmetric]
 command=/jet/run/thrust_stand_control_test_balsaq_main /jet/02_antisymmetric.yaml
 stderr_logfile = /var/log/supervisord/thrust_stand_test-02_antisymmetric-stderr.log
 stdout_logfile = /var/log/supervisord/thrust_stand_test-02_antisymmetric-stdout.log
 autostart = false
+stopsignal=INT
 
 [program:thrust_stand_test-02_symmetric]
 command=/jet/run/thrust_stand_control_test_balsaq_main /jet/02_symmetric.yaml
 stderr_logfile = /var/log/supervisord/thrust_stand_test-02_symmetric-stderr.log
 stdout_logfile = /var/log/supervisord/thrust_stand_test-02_symmetric-stdout.log
 autostart = false
+stopsignal=INT
 
 [program:thrust_stand_test-13_antisymmetric]
 command=/jet/run/thrust_stand_control_test_balsaq_main /jet/13_antisymmetric.yaml
 stderr_logfile = /var/log/supervisord/thrust_stand_test-13_antisymmetric-stderr.log
 stdout_logfile = /var/log/supervisord/thrust_stand_test-13_antisymmetric-stdout.log
 autostart = false
+stopsignal=INT
 
 [program:thrust_stand_test-13_symmetric]
 command=/jet/run/thrust_stand_control_test_balsaq_main /jet/13_symmetric.yaml
 stderr_logfile = /var/log/supervisord/thrust_stand_test-13_symmetric-stderr.log
 stdout_logfile = /var/log/supervisord/thrust_stand_test-13_symmetric-stdout.log
 autostart = false
+stopsignal=INT
 
 [program:thrust_stand_test-all_max]
 command=/jet/run/thrust_stand_control_test_balsaq_main /jet/all_max.yaml
 stderr_logfile = /var/log/supervisord/thrust_stand_test-all_max-stderr.log
 stdout_logfile = /var/log/supervisord/thrust_stand_test-all_max-stdout.log
 autostart = false
+stopsignal=INT
 
 [program:thrust_stand_test-all_min]
 command=/jet/run/thrust_stand_control_test_balsaq_main /jet/all_min.yaml
 stderr_logfile = /var/log/supervisord/thrust_stand_test-all_min-stderr.log
 stdout_logfile = /var/log/supervisord/thrust_stand_test-all_min-stdout.log
 autostart = false
+stopsignal=INT
 
 [inet_http_server]
 port=*:80


### PR DESCRIPTION
Supervisor sends SIGTERM by default when stopping a process. This causes the logger to terminate immediately without the destructor being called. This PR changes the signal sent to SIGINT so that the logger will have an opportunity to flush all its file buffers before exiting.