### PR TITLE
BQ main now dynamically calculates loop sleep

### DIFF
--- a/infrastructure/balsa_queue/bq_main_macro.hh
+++ b/infrastructure/balsa_queue/bq_main_macro.hh
@@ -1,8 +1,10 @@
 #pragma once
 
+#include "infrastructure/comms/mqtt_comms_factory.hh"
+
+#include <chrono>
 #include <signal.h>
 #include <unistd.h>
-#include "infrastructure/comms/mqtt_comms_factory.hh"
 //%deps(paho-mqttpp3)
 
 static bool shutdown = false;
@@ -12,20 +14,26 @@ void signal_handler(int s) {
   shutdown = true;
 }
 
-#define BALSA_QUEUE_MAIN_FUNCTION(bq_type)                               \
-  int main(int argc, char *argv[]) {                                     \
-    struct sigaction sigIntHandler;                                      \
-    sigIntHandler.sa_handler = signal_handler;                           \
-    sigemptyset(&sigIntHandler.sa_mask);                                 \
-    sigIntHandler.sa_flags = 0;                                          \
-    sigaction(SIGINT, &sigIntHandler, NULL);                             \
-    bq_type balsa_queue = bq_type();                                     \
-    balsa_queue.set_comms_factory(std::make_unique<jet::MqttCommsFactory>()); \
-    balsa_queue.init(argc, argv);                                        \
-    while (!shutdown) {                                                  \
-      balsa_queue.loop();                                                \
-      usleep(balsa_queue.loop_delay_microseconds);                       \
-    }                                                                    \
-    balsa_queue.shutdown();                                              \
-    return 0;                                                            \
+#define BALSA_QUEUE_MAIN_FUNCTION(bq_type)                                         \
+  int main(int argc, char *argv[]) {                                               \
+    struct sigaction sigIntHandler;                                                \
+    sigIntHandler.sa_handler = signal_handler;                                     \
+    sigemptyset(&sigIntHandler.sa_mask);                                           \
+    sigIntHandler.sa_flags = 0;                                                    \
+    sigaction(SIGINT, &sigIntHandler, NULL);                                       \
+    bq_type balsa_queue = bq_type();                                               \
+    balsa_queue.set_comms_factory(std::make_unique<jet::MqttCommsFactory>());      \
+    balsa_queue.init(argc, argv);                                                  \
+    std::chrono::high_resolution_clock::time_point start_time;                     \
+    while (!shutdown) {                                                            \
+      start_time = std::chrono::high_resolution_clock::now();                      \
+      balsa_queue.loop();                                                          \
+      uint loop_duration = std::chrono::duration_cast<std::chrono::microseconds>(  \
+        std::chrono::high_resolution_clock::now() - start_time).count();           \
+      if (balsa_queue.loop_delay_microseconds > loop_duration) {                   \
+        usleep(balsa_queue.loop_delay_microseconds - loop_duration);               \
+      }                                                                            \
+    }                                                                              \
+    balsa_queue.shutdown();                                                        \
+    return 0;                                                                      \
   }


### PR DESCRIPTION
BQ main previously did not adjust sleep time to account for the duration of loop execution. Now it does.