### PR TITLE
Make fiducial detection code match the printed fiducial

### DIFF
--- a/vision/fiducial_detection_and_pose.hh
+++ b/vision/fiducial_detection_and_pose.hh
@@ -28,12 +28,12 @@ std::vector<MarkerInWorld> get_world_from_marker_centers(const cv::Mat& camera_i
 
 std::optional<SE3> detect_board(const cv::Mat& input_image);
 
-constexpr float FIDUCIAL_WIDTH_METERS = 30.25 / 1000;
-constexpr float FIDUCIAL_GAP_WIDTH_METERS = 22.98 / 1000;
+constexpr float FIDUCIAL_WIDTH_METERS = 31.0 / 1000;
+constexpr float FIDUCIAL_GAP_WIDTH_METERS = 23.5 / 1000;
 
 
 inline cv::Ptr<cv::aruco::Dictionary> get_aruco_dictionary(){
-    return cv::aruco::getPredefinedDictionary(cv::aruco::DICT_5X5_250);
+    return cv::aruco::getPredefinedDictionary(cv::aruco::DICT_6X6_250);
 }
 
 

--- a/vision/fiducial_detection_balsaq.cc
+++ b/vision/fiducial_detection_balsaq.cc
@@ -1,6 +1,5 @@
 //%bin(fiducial_detection_balsaq_main)
 //%deps(balsa_queue)
-//%deps(image_message)
 
 #include "vision/fiducial_detection_balsaq.hh"
 #include "camera/camera_image_message.hh"

--- a/vision/fiducial_detection_balsaq.cc
+++ b/vision/fiducial_detection_balsaq.cc
@@ -1,6 +1,6 @@
 //%bin(fiducial_detection_balsaq_main)
 //%deps(balsa_queue)
-//%deps(message)
+//%deps(image_message)
 
 #include "vision/fiducial_detection_balsaq.hh"
 #include "camera/camera_image_message.hh"
@@ -19,12 +19,19 @@ void FidicualDetectionBq::init(int argc, char *argv[]) {
 }
 
 void FidicualDetectionBq::loop() {
-  CameraImageMessage message;
-  if (subscriber_->read(message, 1)) {
-    const cv::Mat camera_frame = get_image_mat(message);
+  CameraImageMessage image_message;
+
+  // Wait until we have the latest image_message
+  bool got_msg = false;
+  while (subscriber_->read(image_message, 1)) {
+    got_msg = true;
+  }
+
+  if (got_msg) {
+    const cv::Mat camera_frame = get_image_mat(image_message);
     const std::optional<SE3> board_from_camera = detect_board(camera_frame);
     if (board_from_camera) {
-      // publish a message using *board_from_camera
+      // publish a fiducial message using *board_from_camera
       FiducialDetectionMessage detection_message;
       const jcc::Vec6 log_fiducial_from_camera = board_from_camera->log();
       detection_message.fiducial_from_camera_log[0] = log_fiducial_from_camera[0];
@@ -33,6 +40,9 @@ void FidicualDetectionBq::loop() {
       detection_message.fiducial_from_camera_log[3] = log_fiducial_from_camera[3];
       detection_message.fiducial_from_camera_log[4] = log_fiducial_from_camera[4];
       detection_message.fiducial_from_camera_log[5] = log_fiducial_from_camera[5];
+
+      detection_message.timestamp = image_message.timestamp;
+
       publisher_->publish(detection_message);
       // reconstruct with eg
       // board_from_camera = SE3::exp(Eigen::Map<jcc::Vec6>>(array));
@@ -41,11 +51,11 @@ void FidicualDetectionBq::loop() {
     // respectively. They can be provided in any unit, having in mind that the estimated
     // pose for this board will be measured in the same units (in general, meters are
     // used).
-    cv::Mat board_image;
-    get_aruco_board()->draw(cv::Size(900, 900), board_image, 50, 1);
     if (OPEN_DEBUG_WINDOWS) {
+      cv::Mat board_image;
+      get_aruco_board()->draw(cv::Size(900, 900), board_image, 50, 1);
       cv::imshow("board image", board_image);
-      cv::waitKey(2);
+      cv::waitKey(1);
 
       cv::imshow("camera image", camera_frame);
       cv::waitKey(1);

--- a/vision/fiducial_detection_message.cc
+++ b/vision/fiducial_detection_message.cc
@@ -1,1 +1,10 @@
 #include "vision/fiducial_detection_message.hh"
+
+namespace jet {
+SE3 FiducialDetectionMessage::fiducial_from_camera() const {
+  // Create a copy-less map
+  const Eigen::Map<const jcc::Vec6> fiducial_from_camera_log_eigen(fiducial_from_camera_log.data());
+  return SE3::exp(fiducial_from_camera_log_eigen);
+}
+
+}  // namespace jet

--- a/vision/fiducial_detection_message.hh
+++ b/vision/fiducial_detection_message.hh
@@ -13,7 +13,13 @@ namespace jet {
 
 struct FiducialDetectionMessage : Message {
   std::array<double, 6> fiducial_from_camera_log;
-  MESSAGE(FiducialDetectionMessage, fiducial_from_camera_log);
+
+  // Timestamp of the image that was used to generate this
+  Timestamp timestamp;
+
+  SE3 fiducial_from_camera() const;
+
+  MESSAGE(FiducialDetectionMessage, fiducial_from_camera_log, timestamp);
 };
 
 }  //  namespace jet


### PR DESCRIPTION
Includes a few key changes:
- Adds timestamps to fiducial detection messages
- Doesn't draw an image in the bq unless debug is enabled
- Changes 5x5 -> 6x6