### PR TITLE
Update timestamp to support camera use case

### DIFF
--- a/camera/camera_balsaq.cc
+++ b/camera/camera_balsaq.cc
@@ -66,7 +66,7 @@ void CameraBq::loop() {
   std::cout << "Camera BQ: trying to get a frame" << std::endl;
 
   if (cap_.read(camera_frame)) {
-    // Get the image capture timestamp
+    // Get the image capture timestamp, which is the time that the first byte was captured, as returned by clock_gettime(). 
     const long int cap_time_msec = cap_.get(cv::CAP_PROP_POS_MSEC);
     const Timestamp cap_time_vehicle = msec_monotonic_to_vehicle_monotonic(cap_time_msec);
     gonogo().go();

--- a/camera/camera_balsaq.cc
+++ b/camera/camera_balsaq.cc
@@ -60,10 +60,16 @@ void CameraBq::loop() {
   cap_.set(cv::CAP_PROP_AUTO_EXPOSURE, camera_config_.auto_exposure);
   cap_.set(cv::CAP_PROP_EXPOSURE, camera_config_.exposure);
 
-  const auto current_time = get_current_time();
-  if (cap_.read(camera_frame)) {
+  if (cap.read(camera_frame)) {
+    // Get the image capture timestamp
+    const long int cap_time_msec = cap.get(cv::CAP_PROP_POS_MSEC);
+    const Timestamp cap_time_vehicle = msec_monotonic_to_vehicle_monotonic(cap_time_msec);
     gonogo().go();
-    last_msg_recvd_timestamp_ = get_current_time();
+    last_msg_recvd_timestamp_ = cap_time_vehicle;
+
+    std::cout << "T: " << cap_time_vehicle << std::endl;
+
+    // Pack a message
     CameraImageMessage message;
     const std::size_t n_elements = camera_frame.rows * camera_frame.cols * 3u;
     message.image_data.resize(n_elements);
@@ -71,13 +77,13 @@ void CameraBq::loop() {
     if (camera_frame.isContinuous()) {
       std::memcpy(message.image_data.data(), camera_frame.data, SIZE_OF_UCHAR * n_elements);
     }
-    message.timestamp = current_time;
+    message.timestamp = cap_time_vehicle;
     message.height = camera_frame.size().height;
     message.width = camera_frame.size().width;
     message.camera_serial_number = camera_serial_number_;
     publisher_->publish(message);
-
     std::cout << "Camera BQ: publishes a camera frame " << message.width << " " << message.height << std::endl;
+  } else {
   }
   if (last_msg_recvd_timestamp_ < get_current_time() - Duration::from_seconds(1)) {
     gonogo().nogo("More than 1 second since last camera frame");
@@ -85,6 +91,29 @@ void CameraBq::loop() {
 }
 void CameraBq::shutdown() {
   std::cout << "Camera BQ shutting down." << std::endl;
+}
+
+Timestamp CameraBq::msec_monotonic_to_vehicle_monotonic(long int cap_time_msec) const {
+  // Get the reported monotonic time in milliseconds
+  const std::chrono::milliseconds cap_time_monotonic_msec(cap_time_msec);
+  // Convert it to a timepoint
+  const std::chrono::time_point<std::chrono::steady_clock> cap_time_monotonic(cap_time_monotonic_msec);
+
+  // Get the current time in monotonic
+  const auto cur_time_monotonic = std::chrono::steady_clock::now();
+  // Get the current time in the vehicle wall clock
+  const auto cur_time_vehicle = get_current_time().time_point();
+  const auto cur_time_from_cap_time = cur_time_monotonic - cap_time_monotonic;
+  const auto cap_time_vehicle = cur_time_vehicle - cur_time_from_cap_time;
+
+  const auto wall_from_monotonic = (cur_time_vehicle.time_since_epoch()) - (cur_time_monotonic.time_since_epoch());
+
+  std::cout << "Offset:              " << cur_time_from_cap_time.count() << std::endl;
+  std::cout << "Cap msec:            " << cap_time_msec << std::endl;
+  std::cout << "Monotonic:           " << cur_time_monotonic.time_since_epoch().count() << std::endl;
+  std::cout << "Wall from monotonic: " << wall_from_monotonic.count() << std::endl;
+
+  return Timestamp(cap_time_vehicle);
 }
 
 }  // namespace jet

--- a/camera/camera_balsaq.cc
+++ b/camera/camera_balsaq.cc
@@ -46,6 +46,8 @@ void CameraBq::init(const Config& config) {
 
   camera_config_ = generate_capture_config(config);
 
+  // Set the buffer to a single image so that we are always grabbing the latest frame
+  cap_.set(cv::CAP_PROP_BUFFERSIZE, 1);
   cap_.set(cv::CAP_PROP_FRAME_WIDTH, camera_config_.width_pixels);
   cap_.set(cv::CAP_PROP_FRAME_HEIGHT, camera_config_.height_pixels);
   cap_.set(cv::CAP_PROP_FPS, camera_config_.frames_per_second);

--- a/camera/camera_balsaq.cc
+++ b/camera/camera_balsaq.cc
@@ -39,6 +39,7 @@ CameraConfiguration generate_capture_config(const Config& config) {
 }  // namespace
 
 void CameraBq::init(const Config& config) {
+  loop_delay_microseconds = 0;
   const Camera camera = camera_manager_.get_camera(config["serial_number"].as<std::string>());
   camera_serial_number_ = camera.serial_number;
   std::cout << "Camera BQ: camera serial " << config["serial_number"].as<std::string>() << std::endl;
@@ -48,6 +49,8 @@ void CameraBq::init(const Config& config) {
 
   // Set the buffer to a single image so that we are always grabbing the latest frame
   cap_.set(cv::CAP_PROP_BUFFERSIZE, 1);
+
+  cap_.set(cv::CAP_PROP_FOURCC ,cv::VideoWriter::fourcc('M', 'J', 'P', 'G') );
   cap_.set(cv::CAP_PROP_FRAME_WIDTH, camera_config_.width_pixels);
   cap_.set(cv::CAP_PROP_FRAME_HEIGHT, camera_config_.height_pixels);
   cap_.set(cv::CAP_PROP_FPS, camera_config_.frames_per_second);

--- a/camera/camera_balsaq.hh
+++ b/camera/camera_balsaq.hh
@@ -3,6 +3,7 @@
 
 #include "infrastructure/balsa_queue/balsa_queue.hh"
 #include "camera/camera_image_message.hh"
+#include "infrastructure/balsa_queue/balsa_queue.hh"
 #include "infrastructure/comms/mqtt_comms_factory.hh"
 #include "camera/camera_manager.hh"
 
@@ -38,6 +39,15 @@ class CameraBq : public BalsaQ {
   void shutdown();
 
  private:
+  // Use this to convert a capture time to a wall time
+  //
+  // @param msec_monotonic The timestamp in int milliseconds reported by "the" monotonic clock
+  //
+  // The camera capture times are reported in millseconds from monotonic clock start
+  // This function reconstructs a a reasonable approximation of the *vehicle* time
+  // associated with that monotonic time
+  Timestamp msec_monotonic_to_vehicle_monotonic(long int msec_monotonic) const;
+  static const int CAMERA_FPS = 10;
   PublisherPtr publisher_;
   cv::VideoCapture cap_;
   Timestamp last_msg_recvd_timestamp_;

--- a/config/hoverjet/camera.yaml
+++ b/config/hoverjet/camera.yaml
@@ -5,9 +5,9 @@ frames_per_second: 30
 # Disable autofocus
 auto_focus: 0
 # Disables autoexposure...allegedly?
-auto_exposure: 0.25
+auto_exposure: 1
 # Set a fixed exposure (The minimum)
-webcam_exposure: 0.1
+webcam_exposure: 3
 
 # Calling our shots: The camera we expect to be running
 serial_number: 5CFD076E

--- a/config/jake_bench/camera.yaml
+++ b/config/jake_bench/camera.yaml
@@ -5,9 +5,9 @@ frames_per_second: 30
 # Disable autofocus
 auto_focus: 0
 # Disables autoexposure...allegedly?
-auto_exposure: 0.25
+auto_exposure: 1
 # Set a fixed exposure (The minimum)
-webcam_exposure: 0.1
+webcam_exposure: 3
 
 # Calling our shots: The camera we expect to be running
 serial_number: 0718D9AE

--- a/infrastructure/balsa_queue/balsa_queue.cc
+++ b/infrastructure/balsa_queue/balsa_queue.cc
@@ -36,10 +36,8 @@ std::unique_ptr<Subscriber> BalsaQ::make_subscriber(const std::string& channel_n
   return comms_factory_->make_subscriber(channel_name);
 }
 
-Timestamp BalsaQ::get_current_time() {
-  return std::chrono::duration_cast<std::chrono::nanoseconds>(
-             std::chrono::high_resolution_clock::now().time_since_epoch())
-      .count();
+Timestamp BalsaQ::get_current_time() const {
+  return Timestamp::current_time();
 }
 
 }  // namespace jet

--- a/infrastructure/balsa_queue/balsa_queue.hh
+++ b/infrastructure/balsa_queue/balsa_queue.hh
@@ -46,7 +46,7 @@ class BalsaQ {
  protected:
   std::unique_ptr<Publisher> make_publisher(const std::string& channel_name);
   std::unique_ptr<Subscriber> make_subscriber(const std::string& channel_name);
-  Timestamp get_current_time();
+  Timestamp get_current_time() const;
 
  private:
   GoNoGo gonogo_ = GoNoGo();

--- a/infrastructure/time/timestamp.hh
+++ b/infrastructure/time/timestamp.hh
@@ -1,24 +1,60 @@
 #pragma once
 
+#include <chrono>
+
 #include "infrastructure/comms/serialization/serialization_macros.hh"
 
 namespace jet {
 
 class Timestamp {
  public:
+  // So that everything uses the same block
+  using Clock = std::chrono::system_clock;
+  using ClockPoint = Clock::time_point;
+  using TimestampRatio = std::chrono::nanoseconds;
+
   Timestamp() = default;
-  Timestamp(const uint64_t time) {
-    timestamp_ = time;
+  Timestamp(const uint64_t nanoseconds_since_epoch) {
+    timestamp_ = nanoseconds_since_epoch;
   };
+
+  // Construct from a std::chrono timepoint, namely the `Clock` specified in this header
+  Timestamp(const ClockPoint& time) {
+    const auto time_nanos = std::chrono::duration_cast<TimestampRatio>(time.time_since_epoch());
+    timestamp_ = time_nanos.count();
+  }
+
   operator uint64_t() const {
     return timestamp_;
   }
 
+  // Get the timepoint associated with this timestamp
+  ClockPoint time_point() const {
+    TimestampRatio nanoseconds(timestamp_);
+    return ClockPoint{} + nanoseconds;
+  }
+
+  // Get the current time from the timestamp clock
+  static Timestamp current_time() {
+    return Timestamp(current_time_point());
+  }
+
  private:
+  // Get the current time from the timestamp clock as a time point
+  static ClockPoint current_time_point() {
+    return Clock::now();
+  }
+
   uint64_t timestamp_{0};
 
  public:
   SERIALIZABLE_STRUCTURE(Timestamp, timestamp_);
 };
+
+// Shove the timestamp into an ostream
+inline std::ostream& operator<<(std::ostream& out, const Timestamp& timestamp) {
+  out << uint64_t(timestamp);
+  return out;
+}
 
 }  // namespace jet

--- a/infrastructure/time/timestamp.hh
+++ b/infrastructure/time/timestamp.hh
@@ -9,8 +9,8 @@ namespace jet {
 class Timestamp {
  public:
   // So that everything uses the same block
-  using Clock = std::chrono::system_clock;
-  using ClockPoint = Clock::time_point;
+  using SystemClock = std::chrono::system_clock;
+  using ClockPoint = SystemClock::time_point;
   using TimestampRatio = std::chrono::nanoseconds;
 
   Timestamp() = default;
@@ -18,7 +18,7 @@ class Timestamp {
     timestamp_ = nanoseconds_since_epoch;
   };
 
-  // Construct from a std::chrono timepoint, namely the `Clock` specified in this header
+  // Construct from a std::chrono timepoint, namely the `SystemClock` specified in this header
   Timestamp(const ClockPoint& time) {
     const auto time_nanos = std::chrono::duration_cast<TimestampRatio>(time.time_since_epoch());
     timestamp_ = time_nanos.count();
@@ -42,7 +42,7 @@ class Timestamp {
  private:
   // Get the current time from the timestamp clock as a time point
   static ClockPoint current_time_point() {
-    return Clock::now();
+    return SystemClock::now();
   }
 
   uint64_t timestamp_{0};


### PR DESCRIPTION
Timestamp is able to report clock
Clock is exposed in header
(Switched from high_resolution clock; can switch back if preferred, [here's some arguments as to why](https://stackoverflow.com/questions/38252022/does-standard-c11-guarantee-that-high-resolution-clock-measure-real-time-non) )