### PR TITLE
TurbineBQ now listens to GoNoGo signal

### DIFF
--- a/infrastructure/engine/turbine_interface_bq.cc
+++ b/infrastructure/engine/turbine_interface_bq.cc
@@ -30,6 +30,7 @@ void TurbineInterfaceBQ::init(int argc, char* argv[]) {
   turbine_ignition_subscriber_ = make_subscriber("turbine_ignition");
   turbine_throttle_setting_subscriber_ = make_subscriber("turbine_set_throttle");
   turbine_state_publisher_ = make_publisher("turbine_state");
+  go_no_go_subscriber_ = make_subscriber("GoNoGo/output");
 
   turbine_ptr_ = std::make_unique<JetCatTurbine>(SERIAL_PORT_PATH);
 }
@@ -77,11 +78,7 @@ void TurbineInterfaceBQ::set_target_rpm(uint32_t target_rpm) {
 void TurbineInterfaceBQ::loop() {
   // Check to see if we have any new commands we should send to the turbine.
   TurbineIgnitionCommandMessage ignition_command_message;
-  bool ignition_command_found = false;
-  while (turbine_ignition_subscriber_->read(ignition_command_message, 0)) {
-    ignition_command_found = true;
-  }
-  if (ignition_command_found) {
+  if (turbine_ignition_subscriber_->read_latest(ignition_command_message, 0)) {
     if (ignition_command_message.command == IgnitionCommand::START) {
       start_turbine();
     } else if (ignition_command_message.command == IgnitionCommand::STOP) {
@@ -89,13 +86,15 @@ void TurbineInterfaceBQ::loop() {
     }
   }
 
-  ThrottleCommandMessage throttle_command_message;
-  bool throttle_command_found = false;
-  while (turbine_throttle_setting_subscriber_->read(throttle_command_message, 0)) {
-    throttle_command_found = true;
-  }
-  if (throttle_command_found) {
-    set_thrust_percent(throttle_command_message.throttle_percent);
+  go_no_go_subscriber_->read_latest(go_nogo_message_, 0);
+
+  if (go_nogo_message_.ready) {
+    ThrottleCommandMessage throttle_command_message;
+    if (turbine_throttle_setting_subscriber_->read_latest(throttle_command_message, 0)) {
+      set_thrust_percent(throttle_command_message.throttle_percent);
+    }
+  } else {
+    set_thrust_percent(0);
   }
 
   std::optional<JetCat::LiveValues> live_values = turbine_ptr_->get_live_values();

--- a/infrastructure/engine/turbine_interface_bq.hh
+++ b/infrastructure/engine/turbine_interface_bq.hh
@@ -3,6 +3,7 @@
 #include <infrastructure/balsa_queue/balsa_queue.hh>
 
 #include "infrastructure/engine/jetcat_turbine.hh"
+#include "infrastructure/gonogo/gonogo_message.hh"
 
 namespace jet {
 
@@ -22,7 +23,10 @@ class TurbineInterfaceBQ : public BalsaQ {
   std::unique_ptr<JetCatTurbine> turbine_ptr_;
   SubscriberPtr turbine_ignition_subscriber_;
   SubscriberPtr turbine_throttle_setting_subscriber_;
+  SubscriberPtr go_no_go_subscriber_;
   PublisherPtr turbine_state_publisher_;
+
+  GoNoGoMessage go_nogo_message_;
 
   Timestamp last_turbine_read_time_{0};
 };

--- a/infrastructure/gonogo/gonogo_bq.cc
+++ b/infrastructure/gonogo/gonogo_bq.cc
@@ -1,0 +1,42 @@
+//%deps(balsa_queue)
+//%deps(message)
+
+#include "infrastructure/gonogo/gonogo_bq.hh"
+#include "infrastructure/balsa_queue/bq_main_macro.hh"
+
+#include "infrastructure/comms/mqtt_comms_factory.hh"
+#include "infrastructure/comms/schemas/demo_message.hh"
+
+#include <iostream>
+
+namespace jet {
+
+void GoNoGoBQ::init(int argc, char *argv[]) {
+  loop_delay_microseconds = 10000;
+  gonogo_subscriber_ = make_subscriber("GoNoGo");
+  gonogo_state_publisher_ = make_publisher("GoNoGo/output");
+}
+
+void GoNoGoBQ::loop() {
+  GoNoGoMessage message;
+  while (gonogo_subscriber_->read(message, 1)) {
+    go_no_go_states_[message.bq_name] = message;
+  }
+  for (const auto& state : go_no_go_states_)
+  {
+    if (!state.second.ready) {
+      GoNoGoMessage go_nogo_message;
+      go_nogo_message.ready = false;
+      gonogo_state_publisher_->publish(go_nogo_message);
+      std::cerr << "NOGO because: " << go_nogo_message.bq_name << ":" << go_nogo_message.status_message << std::endl;
+    }
+  }
+}
+
+void GoNoGoBQ::shutdown() {
+  std::cout << "Shutting down!" << std::endl;
+}
+
+}  // namespace jet
+
+BALSA_QUEUE_MAIN_FUNCTION(jet::GoNoGoBQ)

--- a/infrastructure/gonogo/gonogo_bq.hh
+++ b/infrastructure/gonogo/gonogo_bq.hh
@@ -1,0 +1,24 @@
+#pragma once
+
+#include <infrastructure/balsa_queue/balsa_queue.hh>
+#include <infrastructure/gonogo/gonogo_message.hh>
+
+#include <map>
+
+namespace jet {
+
+class GoNoGoBQ : public BalsaQ {
+ public:
+  GoNoGoBQ() = default;
+  void init(int argc, char *argv[]);
+  void loop();
+  void shutdown();
+
+ private:
+  SubscriberPtr gonogo_subscriber_;
+  PublisherPtr gonogo_state_publisher_;
+
+  std::map<std::string, GoNoGoMessage> go_no_go_states_;
+};
+
+}  // namespace jet


### PR DESCRIPTION
1. Added a Go/NoGo aggregator that sets a higher level "No Go" when any GoNoGo source becomes "NoGo".
2. Turbine BQ now listens to this high level Go/NoGo message and sets the turbine RPM to 0 if any BQ reports "No Go" status