### PR TITLE
Adding a Joystick based turbine control utility

### DIFF
--- a/infrastructure/engine/turbine_control.cc
+++ b/infrastructure/engine/turbine_control.cc
@@ -1,0 +1,63 @@
+
+#include "infrastructure/joystick/joystick.hh"
+#include "infrastructure/comms/mqtt_comms_factory.hh"
+#include "infrastructure/engine/throttle_command_message.hh"
+#include "infrastructure/engine/turbine_ignition_message.hh"
+
+#include <unistd.h>
+#include <memory>
+
+const uint8_t ENGINE_STOP_BUTTON_ID = 17;
+const uint8_t ENGINE_START_BUTTON_ID = 30;
+const uint8_t THROTTLE_AXIS_ID = 2;
+
+int main(int argc, char *argv[]) {
+  auto comms_factory = std::make_unique<jet::MqttCommsFactory>();
+  auto throttle_publisher = comms_factory->make_publisher("turbine_set_throttle");
+  auto ignition_publisher = comms_factory->make_publisher("turbine_ignition");
+
+  jet::Joystick joystick("/dev/input/js0");
+  while (true) {
+    auto event = joystick.read_event();
+    if (!event) {
+      continue;
+    }
+    switch (event->event_type) {
+      case jet::EventType::BUTTON: {
+        if (event->axis_id == ENGINE_START_BUTTON_ID) {
+          if (*event->button_state == jet::ButtonState::RELEASED) {
+            jet::TurbineIgnitionCommandMessage ignition_command_message;
+            ignition_command_message.command = jet::IgnitionCommand::START;
+            ignition_publisher->publish(ignition_command_message);
+            std::cout << "Engine Start" << std::endl;
+          }
+        }
+        else if (event->axis_id == ENGINE_STOP_BUTTON_ID) {
+          if ( *event->button_state == jet::ButtonState::RELEASED) {
+            jet::TurbineIgnitionCommandMessage ignition_command_message;
+            ignition_command_message.command = jet::IgnitionCommand::STOP;
+            ignition_publisher->publish(ignition_command_message);
+            std::cout << "Engine Stop" << std::endl;
+          }
+        }
+        else {
+          std::cerr << "Unrecognized button input on button " << unsigned(event->axis_id) << std::endl;
+        }
+        break;
+      }
+      case jet::EventType::AXIS: {
+        if (event->axis_id == THROTTLE_AXIS_ID)
+        {
+          uint32_t throttle_percent = 100 - 100 * ((*event->axis_value) + INT16_MAX) / (INT16_MAX * 2);
+          jet::ThrottleCommandMessage throttle_command_message;
+          throttle_command_message.throttle_percent = throttle_percent;
+          throttle_publisher->publish(throttle_command_message);
+          std::cout << "Throttle set to " << throttle_percent << "%" << std::endl;
+        }
+        break;
+      }
+      default:
+        break;
+    }
+  }
+}

--- a/infrastructure/engine/turbine_control.cc
+++ b/infrastructure/engine/turbine_control.cc
@@ -1,8 +1,8 @@
 
-#include "infrastructure/joystick/joystick.hh"
 #include "infrastructure/comms/mqtt_comms_factory.hh"
 #include "infrastructure/engine/throttle_command_message.hh"
 #include "infrastructure/engine/turbine_ignition_message.hh"
+#include "infrastructure/joystick/joystick.hh"
 
 #include <unistd.h>
 #include <memory>
@@ -10,54 +10,65 @@
 const uint8_t ENGINE_STOP_BUTTON_ID = 17;
 const uint8_t ENGINE_START_BUTTON_ID = 30;
 const uint8_t THROTTLE_AXIS_ID = 2;
+const uint8_t THROTTLE_BUTTON_COUNT = 32;
 
-int main(int argc, char *argv[]) {
+std::vector<std::string> devices{"/dev/input/js0", "/dev/input/js1", "/dev/input/js2", "none"};
+
+int main(int argc, char* argv[]) {
   auto comms_factory = std::make_unique<jet::MqttCommsFactory>();
   auto throttle_publisher = comms_factory->make_publisher("turbine_set_throttle");
   auto ignition_publisher = comms_factory->make_publisher("turbine_ignition");
 
-  jet::Joystick joystick("/dev/input/js0");
-  while (true) {
-    auto event = joystick.read_event();
-    if (!event) {
-      continue;
+  std::unique_ptr<jet::Joystick> throttle;
+
+  for (auto& device : devices) {
+    if (device == "end") {
+      throttle = nullptr;
+      break;
     }
-    switch (event->event_type) {
-      case jet::EventType::BUTTON: {
-        if (event->axis_id == ENGINE_START_BUTTON_ID) {
-          if (*event->button_state == jet::ButtonState::RELEASED) {
-            jet::TurbineIgnitionCommandMessage ignition_command_message;
-            ignition_command_message.command = jet::IgnitionCommand::START;
-            ignition_publisher->publish(ignition_command_message);
-            std::cout << "Engine Start" << std::endl;
+    throttle = std::make_unique<jet::Joystick>(device);
+    if (throttle->get_button_count() == THROTTLE_BUTTON_COUNT) {
+      break;
+    }
+  }
+
+  while (true) {
+    auto throttle_event = throttle->read_event();
+    if (throttle_event) {
+      switch (throttle_event->event_type) {
+        case jet::EventType::BUTTON: {
+          if (throttle_event->axis_id == ENGINE_START_BUTTON_ID) {
+            if (*throttle_event->button_state == jet::ButtonState::RELEASED) {
+              jet::TurbineIgnitionCommandMessage ignition_command_message;
+              ignition_command_message.command = jet::IgnitionCommand::START;
+              ignition_publisher->publish(ignition_command_message);
+              std::cout << "Engine Start" << std::endl;
+            }
+          } else if (throttle_event->axis_id == ENGINE_STOP_BUTTON_ID) {
+            if (*throttle_event->button_state == jet::ButtonState::RELEASED) {
+              jet::TurbineIgnitionCommandMessage ignition_command_message;
+              ignition_command_message.command = jet::IgnitionCommand::STOP;
+              ignition_publisher->publish(ignition_command_message);
+              std::cout << "Engine Stop" << std::endl;
+            }
+          } else {
+            std::cerr << "Unrecognized button input on button " << unsigned(throttle_event->axis_id) << std::endl;
           }
+          break;
         }
-        else if (event->axis_id == ENGINE_STOP_BUTTON_ID) {
-          if ( *event->button_state == jet::ButtonState::RELEASED) {
-            jet::TurbineIgnitionCommandMessage ignition_command_message;
-            ignition_command_message.command = jet::IgnitionCommand::STOP;
-            ignition_publisher->publish(ignition_command_message);
-            std::cout << "Engine Stop" << std::endl;
+        case jet::EventType::AXIS: {
+          if (throttle_event->axis_id == THROTTLE_AXIS_ID) {
+            uint32_t throttle_percent = 100 - 100 * ((*throttle_event->axis_value) + INT16_MAX) / (INT16_MAX * 2);
+            jet::ThrottleCommandMessage throttle_command_message;
+            throttle_command_message.throttle_percent = throttle_percent;
+            throttle_publisher->publish(throttle_command_message);
+            std::cout << "Throttle set to " << throttle_percent << "%" << std::endl;
           }
+          break;
         }
-        else {
-          std::cerr << "Unrecognized button input on button " << unsigned(event->axis_id) << std::endl;
-        }
-        break;
+        default:
+          break;
       }
-      case jet::EventType::AXIS: {
-        if (event->axis_id == THROTTLE_AXIS_ID)
-        {
-          uint32_t throttle_percent = 100 - 100 * ((*event->axis_value) + INT16_MAX) / (INT16_MAX * 2);
-          jet::ThrottleCommandMessage throttle_command_message;
-          throttle_command_message.throttle_percent = throttle_percent;
-          throttle_publisher->publish(throttle_command_message);
-          std::cout << "Throttle set to " << throttle_percent << "%" << std::endl;
-        }
-        break;
-      }
-      default:
-        break;
     }
   }
 }

--- a/infrastructure/joystick/joystick_command_message.hh
+++ b/infrastructure/joystick/joystick_command_message.hh
@@ -1,0 +1,15 @@
+#pragma once
+
+#include "infrastructure/comms/schemas/message.hh"
+#include "infrastructure/comms/serialization/serialization_macros.hh"
+
+namespace jet {
+
+
+struct JoystickCommandMessage : Message {
+  double command;
+
+  MESSAGE(JoystickCommandMessage, command);
+};
+
+}  // namespace jet

--- a/infrastructure/joystick/joystick_test.cc
+++ b/infrastructure/joystick/joystick_test.cc
@@ -2,7 +2,8 @@
 #include "infrastructure/joystick/joystick.hh"
 
 int main(int argc, char *argv[]) {
-  jet::Joystick joystick("/dev/input/js0");
+  jet::Joystick joystick("/dev/input/js2");
+  // jet::Joystick joystick("/dev/input/by-id/usb-Thustmaster_Joystick_-_HOTAS_Warthog-joystick");
   while (true) {
     auto event = joystick.read_event();
     if (!event) {

--- a/infrastructure/joystick/pitch_roll_control.cc
+++ b/infrastructure/joystick/pitch_roll_control.cc
@@ -1,0 +1,54 @@
+
+#include "infrastructure/comms/mqtt_comms_factory.hh"
+#include "infrastructure/joystick/joystick.hh"
+#include "infrastructure/joystick/joystick_command_message.hh"
+
+#include <unistd.h>
+#include <memory>
+
+const uint8_t PITCH_AXIS_ID = 1;
+const uint8_t ROLL_AXIS_ID = 0;
+const uint8_t JOYSTICK_BUTTON_COUNT = 19;
+
+std::vector<std::string> devices{"/dev/input/js0", "/dev/input/js1", "/dev/input/js2", "end"};
+
+int main(int argc, char* argv[]) {
+  auto comms_factory = std::make_unique<jet::MqttCommsFactory>();
+  auto pitch_publisher = comms_factory->make_publisher("/joystick/pitch");
+  auto roll_publisher = comms_factory->make_publisher("/joystick/roll");
+
+  std::unique_ptr<jet::Joystick> joystick;
+
+  for (auto& device : devices) {
+    if (device == "end") {
+      joystick = nullptr;
+      break;
+    }
+    joystick = std::make_unique<jet::Joystick>(device);
+    if (joystick->get_button_count() == JOYSTICK_BUTTON_COUNT) {
+      break;
+    }
+  }
+
+  while (true) {
+    auto joystick_event = joystick->read_event();
+    if (joystick_event) {
+      if (joystick_event->event_type == jet::EventType::AXIS) {
+        if (joystick_event->axis_id == PITCH_AXIS_ID) {
+          double pitch = -1 * ((double)(*joystick_event->axis_value)) / (INT16_MAX);
+          jet::JoystickCommandMessage joystick_command_message;
+          joystick_command_message.command = pitch;
+          pitch_publisher->publish(joystick_command_message);
+          std::cout << "Pitch set to " << pitch << std::endl;
+        }
+        if (joystick_event->axis_id == ROLL_AXIS_ID) {
+          double roll = ((double)(*joystick_event->axis_value)) / (INT16_MAX);
+          jet::JoystickCommandMessage joystick_command_message;
+          joystick_command_message.command = roll;
+          roll_publisher->publish(joystick_command_message);
+          std::cout << "Roll set to " << roll << std::endl;
+        }
+      }
+    }
+  }
+}

--- a/infrastructure/joystick/yaw_control.cc
+++ b/infrastructure/joystick/yaw_control.cc
@@ -1,0 +1,45 @@
+
+#include "infrastructure/comms/mqtt_comms_factory.hh"
+#include "infrastructure/joystick/joystick.hh"
+#include "infrastructure/joystick/joystick_command_message.hh"
+
+#include <unistd.h>
+#include <memory>
+
+const uint8_t YAW_AXIS_ID = 2;
+const uint8_t PEDAL_BUTTON_COUNT = 0;
+
+std::vector<std::string> devices{"/dev/input/js0", "/dev/input/js1", "/dev/input/js2", "end"};
+
+int main(int argc, char* argv[]) {
+  auto comms_factory = std::make_unique<jet::MqttCommsFactory>();
+  auto yaw_publisher = comms_factory->make_publisher("/joystick/yaw");
+
+  std::unique_ptr<jet::Joystick> pedals;
+
+  for (auto& device : devices) {
+    if (device == "end") {
+      pedals = nullptr;
+      break;
+    }
+    pedals = std::make_unique<jet::Joystick>(device);
+    if (pedals->get_button_count() == PEDAL_BUTTON_COUNT) {
+      break;
+    }
+  }
+
+  while (true) {
+    auto pedal_event = pedals->read_event();
+    if (pedal_event) {
+      if (pedal_event->event_type == jet::EventType::AXIS) {
+        if (pedal_event->axis_id == YAW_AXIS_ID) {
+          double yaw = ((double)(*pedal_event->axis_value)) / (INT16_MAX);
+          jet::JoystickCommandMessage joystick_command_message;
+          joystick_command_message.command = yaw;
+          yaw_publisher->publish(joystick_command_message);
+          std::cout << "Yaw set to " << yaw << std::endl;
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
A new utility that allows a user to control the turbine using a joystick. Functions included are:
1. Start turbine
2. Stop turbine
3. Set throttle

This is designed for use with the Thrustmaster Hotas Warthog throttle unit, but to use it with a different stick, just change the constants at the top of the file. In the future this will be done via config.