### PR TITLE
Fixes bug where joystick was comparing size of pointer, not structure

### DIFF
--- a/infrastructure/joystick/joystick.cc
+++ b/infrastructure/joystick/joystick.cc
@@ -18,8 +18,8 @@ Joystick::~Joystick() {
 }
 
 std::optional<JoystickEvent> Joystick::read_event() {
-  size_t bytes = read(joystick_fd_, &event_buffer_, sizeof(&event_buffer_));
-  if (bytes == sizeof(&event_buffer_)) {
+  size_t bytes = read(joystick_fd_, &event_buffer_, sizeof(event_buffer_));
+  if (bytes == sizeof(event_buffer_)) {
     JoystickEvent event;
     event.timestamp_ms = event_buffer_.time;
     if (!int_to_enum(event_buffer_.type, event.event_type)) {


### PR DESCRIPTION
This bug was not noticed initially because it actually works fine on x86. When run on ARM, the pointer size is dissimilar enough from the structure size that reading from the joystick always fails.