### PR TITLE
Reduce size of Docker images by deleting OpenCV source

### DIFF
--- a/infrastructure/scripts/docker/Dockerfile
+++ b/infrastructure/scripts/docker/Dockerfile
@@ -127,5 +127,7 @@ RUN ldconfig
 RUN cd /; apt install libgtk2.0-dev libavcodec-dev libavformat-dev libswscale-dev -y
 RUN git clone https://github.com/opencv/opencv_contrib.git --depth=1
 RUN cd opencv_contrib; CONTRIB_PATH=$PWD; git reset --hard a17185c6dc7aa554591ad1be38923232472f8001; cd ..; git clone https://github.com/opencv/opencv.git --depth=1; cd opencv; git reset --hard e2dbf054ac5c54bd328f648d9d6146c09dfd5484; mkdir build; cd build; cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/usr/local -DOPENCV_EXTRA_MODULES_PATH=$CONTRIB_PATH/modules ..; make -j3; make install
+RUN rm -rf opencv
+RUN rm -rf opencv_contrib
 
 RUN ldconfig -p


### PR DESCRIPTION
OpenCV source contains tons of data and other goofy nonsense. This deletes all of it when the image is built. Running these *commands* seems to work locally, but I am still too simple-minded to actually build the Docker image.