### PR TITLE
Change gonogo state transition printout

### DIFF
--- a/camera/camera_balsaq.cc
+++ b/camera/camera_balsaq.cc
@@ -37,7 +37,7 @@ void CameraBq::loop() {
 
   const auto current_time = get_current_time();
   if (cap.read(camera_frame)) {
-    gonogo_.go();
+    gonogo().go();
     last_msg_recvd_timestamp_ = get_current_time();
     CameraImageMessage message;
     const std::size_t n_elements = camera_frame.rows * camera_frame.cols * 3u;
@@ -54,7 +54,7 @@ void CameraBq::loop() {
     std::cout << "Camera BQ: publishes a camera frame " << message.width << " " << message.height << std::endl;
   }
   if (last_msg_recvd_timestamp_ < get_current_time() - Duration::from_seconds(1)) {
-    gonogo_.nogo("More than 1 second since last camera frame");
+    gonogo().nogo("More than 1 second since last camera frame");
   }
 }
 void CameraBq::shutdown() {

--- a/camera/camera_viewer_bq.cc
+++ b/camera/camera_viewer_bq.cc
@@ -18,7 +18,7 @@ void CameraViewerBq::loop() {
   }
 
   if (got_msg) {
-    gonogo_.go();
+    gonogo().go();
     const cv::Mat camera_frame = get_image_mat(image_message);
 
     cv::imshow("camera image", camera_frame);

--- a/control/controller_balsaq.cc
+++ b/control/controller_balsaq.cc
@@ -118,7 +118,7 @@ void ControllerBq::loop() {
 
   bool got_pose_msg = false;
   while (pose_sub_->read(pose_msg, 1)) {
-    gonogo_.go();
+    gonogo().go();
     got_pose_msg = true;
   }
 

--- a/embedded/imu_driver/imu_balsaq.cc
+++ b/embedded/imu_driver/imu_balsaq.cc
@@ -16,9 +16,9 @@ void ImuBq::init(const Config& config) {
   std::cout << "IMU starting" << std::endl;
 
   if (imu_driver_.initialize()) {
-    gonogo_.go();
+    gonogo().go();
   } else {
-    gonogo_.nogo("Failed to intialize IMU driver");
+    gonogo().nogo("Failed to intialize IMU driver");
   }
 }
 
@@ -44,9 +44,9 @@ void ImuBq::loop() {
   msg.mag_utesla_z = mag_utesla.z();
 
   if (msg.accel_mpss_x == 0 && msg.accel_mpss_y == 0 && msg.accel_mpss_z == 0) {
-    gonogo_.nogo("IMU reading all zeroes!");
+    gonogo().nogo("IMU reading all zeroes!");
   } else {
-    gonogo_.go();
+    gonogo().go();
   }
 
   publisher_->publish(msg);

--- a/embedded/servo_bq/servo_balsaq.cc
+++ b/embedded/servo_bq/servo_balsaq.cc
@@ -33,7 +33,7 @@ void ServoBq::loop() {
   }
 
   if (got_msg) {
-    gonogo_.go();
+    gonogo().go();
     last_msg_recvd_timestamp_ = get_current_time();
     for (uint i = 0; i < message.servo_indices.size(); i++) {
       auto servo_index = message.servo_indices.at(i);
@@ -43,7 +43,7 @@ void ServoBq::loop() {
     }
   }
   if (last_msg_recvd_timestamp_ < get_current_time() - Duration::from_seconds(1)) {
-    gonogo_.nogo("More than 1 second since last servo command");
+    gonogo().nogo("More than 1 second since last servo command");
   }
 }
 void ServoBq::shutdown() {

--- a/filtering/filter_balsaq.cc
+++ b/filtering/filter_balsaq.cc
@@ -63,7 +63,7 @@ void FilterBq::loop() {
       xp0.time_of_validity = fiducial_time_of_validity;
       jf_.reset(xp0);
 
-      gonogo_.go();
+      gonogo().go();
     }
 
     std::cout << "Free-running" << std::endl;

--- a/filtering/filter_viz_balsaq.cc
+++ b/filtering/filter_viz_balsaq.cc
@@ -63,7 +63,7 @@ void FilterVizBq::init(const Config& config) {
   camera_from_body_ = get_camera_extrinsics().camera_from_frame;
 
   std::cout << "Filter Viz starting" << std::endl;
-  gonogo_.go();
+  gonogo().go();
 }
 
 void FilterVizBq::draw_sensors() {

--- a/infrastructure/balsa_queue/balsa_queue.hh
+++ b/infrastructure/balsa_queue/balsa_queue.hh
@@ -4,8 +4,8 @@
 
 #include "infrastructure/comms/comms_factory.hh"
 #include "infrastructure/config/config.hh"
-#include "infrastructure/time/timestamp.hh"
 #include "infrastructure/gonogo/gonogo.hh"
+#include "infrastructure/time/timestamp.hh"
 
 #include <yaml-cpp/yaml.h>
 
@@ -19,13 +19,23 @@ namespace jet {
 class BalsaQ {
  public:
   uint loop_delay_microseconds = 10000;
-  std::string bq_name_;
   BalsaQ() = default;
   virtual void init(const Config& config) = 0;
   virtual void loop() = 0;
   virtual void shutdown() = 0;
 
-  GoNoGo gonogo_ = GoNoGo();
+  const std::string& name() const {
+    return bq_name_;
+  }
+
+  GoNoGo& gonogo() {
+    return gonogo_;
+  }
+
+  void set_name(const std::string& name) {
+    bq_name_ = name;
+  }
+
   void set_comms_factory(std::unique_ptr<CommsFactory> comms_factory);
 
  protected:
@@ -35,6 +45,8 @@ class BalsaQ {
   Timestamp last_msg_recvd_timestamp_;
 
  private:
+  GoNoGo gonogo_ = GoNoGo();
+  std::string bq_name_;
   std::unique_ptr<CommsFactory> comms_factory_;
 };
 

--- a/infrastructure/balsa_queue/bq_main_macro.hh
+++ b/infrastructure/balsa_queue/bq_main_macro.hh
@@ -20,9 +20,9 @@ void signal_handler(int s) {
     sigIntHandler.sa_flags = 0;                                               \
     sigaction(SIGINT, &sigIntHandler, NULL);                                  \
     bq_type balsa_queue = bq_type();                                          \
-    balsa_queue.bq_name_ = #bq_type;                                          \
-    balsa_queue.gonogo_.setName(#bq_type);                                    \
-    balsa_queue.gonogo_.nogo("init");                                         \
+    balsa_queue.set_name(#bq_type);                                          \
+    balsa_queue.gonogo().setName(#bq_type);                                    \
+    balsa_queue.gonogo().nogo("init");                                         \
     balsa_queue.set_comms_factory(std::make_unique<jet::MqttCommsFactory>()); \
     YAML::Node config;                                                        \
     if (argc > 1) {                                                           \

--- a/infrastructure/balsa_queue/bq_main_macro.hh
+++ b/infrastructure/balsa_queue/bq_main_macro.hh
@@ -20,9 +20,9 @@ void signal_handler(int s) {
     sigIntHandler.sa_flags = 0;                                               \
     sigaction(SIGINT, &sigIntHandler, NULL);                                  \
     bq_type balsa_queue = bq_type();                                          \
-    balsa_queue.set_name(#bq_type);                                          \
-    balsa_queue.gonogo().setName(#bq_type);                                    \
-    balsa_queue.gonogo().nogo("init");                                         \
+    balsa_queue.set_name(#bq_type);                                           \
+    balsa_queue.gonogo().setName(#bq_type);                                   \
+    balsa_queue.gonogo().nogo("init");                                        \
     balsa_queue.set_comms_factory(std::make_unique<jet::MqttCommsFactory>()); \
     YAML::Node config;                                                        \
     if (argc > 1) {                                                           \

--- a/infrastructure/gonogo/gonogo.cc
+++ b/infrastructure/gonogo/gonogo.cc
@@ -14,15 +14,15 @@ void GoNoGo::setName(std::string name) {
     gonogomessage_.bq_name = name;
 }
 
-void GoNoGo::go() {
+void GoNoGo::go(const std::string &status_message) {
     // If it's changing state
     if (!gonogomessage_.ready) {
-        std::cout << gonogomessage_.bq_name << ": go=" << gonogomessage_.ready
-        << ", msg=" << gonogomessage_.status_message << std::endl;
+        std::cout << gonogomessage_.bq_name << ": GO!"
+                << ", msg=" << gonogomessage_.status_message << std::endl;
     }
     gonogomessage_.ready = true;
     // for now this is an empty message because the message type won't compile with an optional string
-    gonogomessage_.status_message = "";
+    gonogomessage_.status_message = status_message;
 
     publish_status();
 }
@@ -30,7 +30,7 @@ void GoNoGo::go() {
 void GoNoGo::nogo(const std::string &status_message) {
     // If it's changing state
     if (gonogomessage_.ready){
-      std::cout << gonogomessage_.bq_name << ": go=" << gonogomessage_.ready
+      std::cout << gonogomessage_.bq_name << ": NO GO!"
                 << ", msg=" << gonogomessage_.status_message << std::endl;
     }
     gonogomessage_.ready = false;

--- a/infrastructure/gonogo/gonogo.hh
+++ b/infrastructure/gonogo/gonogo.hh
@@ -10,10 +10,10 @@
 namespace jet {
 
 class GoNoGo {
-  public: 
+  public:
    GoNoGo();
    void setName(std::string name);
-   void go();
+   void go(const std::string &status_message = "");
    void nogo(const std::string &status_message);
 
   private:

--- a/infrastructure/gonogo/gonogo_bq.cc
+++ b/infrastructure/gonogo/gonogo_bq.cc
@@ -1,8 +1,5 @@
 //%bin(gonogo_bq_main)
 
-//%deps(balsa_queue)
-//%deps(message)
-
 #include "infrastructure/gonogo/gonogo_bq.hh"
 #include "infrastructure/balsa_queue/bq_main_macro.hh"
 

--- a/infrastructure/gonogo/gonogo_report_bq.cc
+++ b/infrastructure/gonogo/gonogo_report_bq.cc
@@ -1,0 +1,50 @@
+//%bin(gonogo_report_bq_main)
+
+#include "infrastructure/gonogo/gonogo_report_bq.hh"
+#include "infrastructure/balsa_queue/bq_main_macro.hh"
+
+#include "infrastructure/comms/mqtt_comms_factory.hh"
+
+#include <iostream>
+
+namespace jet {
+
+namespace {
+
+// Print the contents of an go message
+// Tried to make the "GO" and "NOGO" printouts appear visually distinct.
+//
+// Intentionally not overloading ostream operator
+void print_status(const GoNoGoMessage& message) {
+  if (message.ready) {
+    std::cout << message.bq_name << "GO! (" << message.status_message << ")" << std::endl;
+  } else {
+    std::cout << message.bq_name << "--- NO go ---(" << message.status_message << ")" << std::endl;
+  }
+}
+}  // namespace
+
+void GoNoGoReportBQ::init(const Config& config) {
+  gonogo_sub_ = make_subscriber("GoNoGo");
+}
+
+void GoNoGoReportBQ::loop() {
+  GoNoGoMessage message;
+  while (gonogo_sub_->read(message, 1)) {
+    if (!ready_from_bq_name_.count(message.bq_name)) {
+      print_status(message);
+    } else if (ready_from_bq_name_.at(message.bq_name) != message.ready) {
+      print_status(message);
+    }
+
+    ready_from_bq_name_[message.bq_name] = message.ready;
+  }
+}
+
+void GoNoGoReportBQ::shutdown() {
+  std::cout << "Shutting down!" << std::endl;
+}
+
+}  // namespace jet
+
+BALSA_QUEUE_MAIN_FUNCTION(jet::GoNoGoReportBQ)

--- a/infrastructure/gonogo/gonogo_report_bq.hh
+++ b/infrastructure/gonogo/gonogo_report_bq.hh
@@ -7,18 +7,18 @@
 
 namespace jet {
 
-class GoNoGoBQ : public BalsaQ {
+class GoNoGoReportBQ : public BalsaQ {
  public:
-  GoNoGoBQ() = default;
+  GoNoGoReportBQ() = default;
   void init(const Config& config);
   void loop();
   void shutdown();
 
  private:
-  SubscriberPtr gonogo_subscriber_;
-  PublisherPtr gonogo_state_publisher_;
+  SubscriberPtr gonogo_sub_;
+  SubscriberPtr gonogo_state_sub_;
 
-  std::map<std::string, GoNoGoMessage> go_no_go_states_;
+  std::map<std::string, bool> ready_from_bq_name_;
 };
 
 }  // namespace jet

--- a/infrastructure/logging/message_logger_bq.cc
+++ b/infrastructure/logging/message_logger_bq.cc
@@ -35,7 +35,7 @@ void MessageLoggerBQ::init(const Config& config) {
   for (const std::string& channel_name : channels_) {
     subscribers_.emplace_back(channel_name, make_subscriber(channel_name));
   }
-  gonogo_.go();
+  gonogo().go();
 }
 
 void MessageLoggerBQ::loop() {

--- a/infrastructure/time/timesync_bq/timesync_client_bq.cc
+++ b/infrastructure/time/timesync_bq/timesync_client_bq.cc
@@ -20,9 +20,9 @@ void TimesyncClientBq::init(const Config& config) {
   subscriber_ = make_subscriber("timesync_master");
   // gethostname will return 0 if successful, SOCKET_ERROR otherwise
   if (gethostname(client_message_.hostname, HOST_NAME_MAX) != 0) {
-    gonogo_.nogo("Socket Error getting hostname");
+    gonogo().nogo("Socket Error getting hostname");
   } else {
-    gonogo_.go();
+    gonogo().go();
   }
 }
 
@@ -33,9 +33,9 @@ void TimesyncClientBq::loop() {
     client_message_.master_seq_number = master_message.header.sequence_number;
 
     publisher_->publish(client_message_);
-    std::cout << "cl_name:" << client_message_.hostname 
-    << " m_ts:" << client_message_.master_timestamp 
-    << " m_sq:" << client_message_.master_seq_number 
+    std::cout << "cl_name:" << client_message_.hostname
+    << " m_ts:" << client_message_.master_timestamp
+    << " m_sq:" << client_message_.master_seq_number
     << " cl_ts:" << client_message_.header.timestamp_ns
     << " cl_sq:" << client_message_.header.sequence_number
     << " offset:" << (client_message_.header.timestamp_ns - client_message_.master_timestamp) << std::endl;

--- a/infrastructure/time/timesync_bq/timesync_master_bq.cc
+++ b/infrastructure/time/timesync_bq/timesync_master_bq.cc
@@ -15,7 +15,7 @@ namespace jet {
 
 void TimesyncMasterBq::init(const Config& config) {
   publisher_ = make_publisher("timesync_master");
-  gonogo_.go();
+  gonogo().go();
 }
 
 void TimesyncMasterBq::loop() {

--- a/vision/fiducial_detection_balsaq.cc
+++ b/vision/fiducial_detection_balsaq.cc
@@ -29,7 +29,7 @@ void FidicualDetectionBq::loop() {
   }
 
   if (got_msg) {
-    gonogo_.go();
+    gonogo().go();
     last_msg_recvd_timestamp_ = get_current_time();
     const Calibration camera_calibration = camera_manager_.get_camera(image_message.camera_serial_number).calibration;
     const cv::Mat camera_frame = get_image_mat(image_message);
@@ -69,7 +69,7 @@ void FidicualDetectionBq::loop() {
     }
   }
   if (last_msg_recvd_timestamp_ < get_current_time() - Duration::from_seconds(1)) {
-    gonogo_.nogo("More than 1 second since last image message");
+    gonogo().nogo("More than 1 second since last image message");
   }
 }
 


### PR DESCRIPTION
Previously, it would print `ready=0` on transition to `ready=1`, which confused me -- it now prints "GO!" or "NOGO!"

Also adds a listener BQ to be run on supervising laptop