### PR TITLE
Reduce BQ startup error spew

### DIFF
--- a/infrastructure/comms/mqtt_publisher.hh
+++ b/infrastructure/comms/mqtt_publisher.hh
@@ -8,6 +8,16 @@
 
 namespace jet {
 
+namespace {
+inline constexpr int ERROR_MESSAGE_PERIOD = 100;
+}
+
+inline void print_error_rate_limited(uint32_t error_count, std::string_view message) {
+  if (error_count == 1 || error_count % ERROR_MESSAGE_PERIOD == 0) {
+    std::cerr << message << std::endl;
+  }
+}
+
 class MqttPublisher : public Publisher {
  public:
   MqttPublisher(const std::string& channel_name);
@@ -19,6 +29,9 @@ class MqttPublisher : public Publisher {
   std::string mqtt_server_address_;
   std::string mqtt_client_id_;
   std::unique_ptr<mqtt::async_client> mqtt_client_;
+
+  uint32_t sequential_connect_failures_{0};
+  uint32_t sequential_failed_publishes_{0};
 
   void connect();
   void reconnect();


### PR DESCRIPTION
BQs spew a lot of MQTT related errors on startup before they connect to the broker. This PR reduces that spew by removing a few unnecessary messages and rate limiting the more helpful errors.