### PR TITLE
Removing unnecessary member variable from base BQ

### DIFF
--- a/camera/camera_balsaq.hh
+++ b/camera/camera_balsaq.hh
@@ -40,6 +40,7 @@ class CameraBq : public BalsaQ {
  private:
   PublisherPtr publisher_;
   cv::VideoCapture cap;
+  Timestamp last_msg_recvd_timestamp_;
 
   std::string camera_serial_number_;
   CameraConfiguration camera_config_;

--- a/embedded/servo_bq/servo_balsaq.hh
+++ b/embedded/servo_bq/servo_balsaq.hh
@@ -17,6 +17,7 @@ class ServoBq : public BalsaQ {
  private:
   std::vector<ServoDriver> servos;
   SubscriberPtr subscriber;
+  Timestamp last_msg_recvd_timestamp_;
 };
 
 }  // namespace jet

--- a/infrastructure/balsa_queue/balsa_queue.hh
+++ b/infrastructure/balsa_queue/balsa_queue.hh
@@ -42,7 +42,6 @@ class BalsaQ {
   std::unique_ptr<Publisher> make_publisher(const std::string& channel_name);
   std::unique_ptr<Subscriber> make_subscriber(const std::string& channel_name);
   Timestamp get_current_time();
-  Timestamp last_msg_recvd_timestamp_;
 
  private:
   GoNoGo gonogo_ = GoNoGo();

--- a/vision/fiducial_detection_balsaq.hh
+++ b/vision/fiducial_detection_balsaq.hh
@@ -23,6 +23,7 @@ class FidicualDetectionBq : public BalsaQ {
   SubscriberPtr subscriber_;
   static constexpr bool OPEN_DEBUG_WINDOWS = false;
   CameraManager camera_manager_ = CameraManager();
+  Timestamp last_msg_recvd_timestamp_;
 };
 
 }  // namespace jet


### PR DESCRIPTION
The `last_msg_recvd_timestamp_` member of the base BQ class is only used by three BQs, so I'm moving it out of the base class and into the BQs that actually use it.