### PR TITLE
Move PCA9685 to addr 0x43

### DIFF
--- a/embedded/pwm_driver/pwm_driver.cc
+++ b/embedded/pwm_driver/pwm_driver.cc
@@ -16,7 +16,7 @@ https://github.com/adafruit/Adafruit-PWM-Servo-Driver-Library/
 #include <unistd.h> // usleep
 
 // This is for the PCA9685
-#define PCA9685_I2C_ADDR 0x42
+#define PCA9685_I2C_ADDR 0x43 // Solder bridges for A0 and A1 have been bridged
 #define I2C_SLAVE 0x0703
 #define I2C_SLAVE_FORCE 0x0706
 


### PR DESCRIPTION
I did some hardware changes on the jet and had to change the address of the servo driver.