### PR TITLE
Fix valgrind errors from logreader

### DIFF
--- a/infrastructure/logging/log_reader.cc
+++ b/infrastructure/logging/log_reader.cc
@@ -59,10 +59,15 @@ bool LogReader::read_next_message(const std::string& channel_name, Message& mess
   auto channel_it = channels_.find(channel_name);
   if (channel_it != channels_.end()) {
     auto& file = channel_it->second.current_file;
+
     uint32_t channel_id;
     uint32_t message_length;
     file.read((char*) &channel_id, sizeof(uint32_t));
     file.read((char*) &message_length, sizeof(uint32_t));
+
+    if (file.eof()) {
+      return false;
+    }
     std::string message_data(message_length, ' ');
     file.read(&message_data[0], message_length);
     if (!file) {


### PR DESCRIPTION

Valgrind gets confused by the logreader when it tries to read past a file at `eof`. It sometimes tries to allocate arbitrarily large blocks because it reads uninitialized memory into the channel_id and message_length. 

Before
```
channel_id: 3648330128
message_length: 32767
0
channel_id: 0
message_length: 112
1
channel_id: 3648330128
message_length: 32767
0
channel_id: 0
message_length: 112
1
channel_id: 3648330128
message_length: 32767
0
channel_id: 0
message_length: 112
1
channel_id: 3648330128
message_length: 32767
0
channel_id: 0
message_length: 112
1
channel_id: 3648330128
message_length: 32767
1
channel_id: 3648330128
message_length: 32767
```

After
```
channel_id: 0
message_length: 112
0
channel_id: 0
message_length: 112
0
channel_id: 0
message_length: 112
0
channel_id: 0
message_length: 112
```