### PR TITLE
Adds bin comment to top of SubscriberTask demo

### DIFF
--- a/infrastructure/comms/tests/pub_sub_demo_bqs/subscriber_demo_bq.cc
+++ b/infrastructure/comms/tests/pub_sub_demo_bqs/subscriber_demo_bq.cc
@@ -1,4 +1,4 @@
-
+//%bin(subscriber_demo_bq_main)
 //%deps(balsa_queue)
 //%deps(message)
 


### PR DESCRIPTION
The SubscriberDemoTask wasn't building because it was missing the //%bin comment at the top of the file. Added it.