### PR TITLE
Changes BQ configuration field id -> bq_name

### DIFF
--- a/config/hoverjet/imu_1.yaml
+++ b/config/hoverjet/imu_1.yaml
@@ -4,4 +4,4 @@ imus:
     location_description: "In the flight computer avionics bay"
     i2c_address: 0x28
     unique_id: 4e0475ea-5046-4d51-2020-203426290fff
-id: flight_computer_imu
+bq_name: flight_computer_imu

--- a/config/hoverjet/imu_2.yaml
+++ b/config/hoverjet/imu_2.yaml
@@ -4,4 +4,4 @@ imus:
     location_description: "Beneath the primary camera"
     i2c_address: 0x29
     unique_id: 240ebc03-4b46-4d51-2020-204c18340aff
-id: camera_imu
+bq_name: camera_imu

--- a/infrastructure/balsa_queue/bq_main_macro.hh
+++ b/infrastructure/balsa_queue/bq_main_macro.hh
@@ -29,9 +29,9 @@ void signal_handler(int s) {
       }                                                                       \
     }                                                                         \
     bq_type balsa_queue = bq_type();                                          \
-    if (config["id"]) {                                                       \
-      balsa_queue.set_name(config["id"].as<std::string>());                   \
-      balsa_queue.gonogo().setName(config["id"].as<std::string>());           \
+    if (config["bq_name"]) {                                                  \
+      balsa_queue.set_name(config["bq_name"].as<std::string>());              \
+      balsa_queue.gonogo().setName(config["bq_name"].as<std::string>());      \
     } else {                                                                  \
       balsa_queue.set_name(#bq_type);                                         \
       balsa_queue.gonogo().setName(#bq_type);                                 \


### PR DESCRIPTION
Field name ID is ambiguous. Changed it to `bq_name` to disambiguate and to match the terminology used elsewhere in the repo.