### PR TITLE
Remove duplicated image processing in fiducial BQ

### DIFF
--- a/filtering/filter_demo.cc
+++ b/filtering/filter_demo.cc
@@ -28,9 +28,9 @@
 #include "third_party/experiments/geometry/shapes/fit_ellipse.hh"
 
 //
+#include "camera/camera_manager.hh"
 #include "vision/fiducial_detection_and_pose.hh"
 #include "vision/fiducial_detection_message.hh"
-#include "camera/camera_manager.hh"
 
 namespace jet {
 namespace filtering {
@@ -441,7 +441,8 @@ void go() {
         Calibration camera_calibration = camera_manager_.get_camera(cam_msg.camera_serial_number).calibration;
         const auto image = get_image_mat(cam_msg);
 
-        const auto result = estimate_board_center_from_camera_from_image(image, camera_calibration);
+        const auto result =
+            estimate_board_center_from_camera_from_image(get_ids_and_corners(image), camera_calibration);
         if (result) {
           const SE3 world_from_camera = *result;
 

--- a/vision/fiducial_detection_and_pose.cc
+++ b/vision/fiducial_detection_and_pose.cc
@@ -4,7 +4,7 @@
 
 namespace jet {
 
-board_ids_and_corners get_ids_and_corners(const cv::Mat &input_image) {
+BoardIdsAndCorners get_ids_and_corners(const cv::Mat &input_image) {
   std::vector<int> ids;
   std::vector<std::vector<cv::Point2f>> corners;
   const auto params = cv::aruco::DetectorParameters::create();
@@ -14,11 +14,11 @@ board_ids_and_corners get_ids_and_corners(const cv::Mat &input_image) {
   // TODO isaac make aruco_dictionary parameter of this method to allow for
   // multiple unique boards
   cv::aruco::detectMarkers(input_image, get_aruco_dictionary(), corners, ids, params);
-  board_ids_and_corners result = {ids, corners};
+  BoardIdsAndCorners result = {ids, corners};
   return result;
 }
 
-std::vector<BoardPointImagePointAssociation> obj_points_img_points_from_image(const board_ids_and_corners ids_corners) {
+std::vector<BoardPointImagePointAssociation> obj_points_img_points_from_image(const BoardIdsAndCorners ids_corners) {
   cv::Mat boardPoints, imgPoints;
   cv::aruco::getBoardObjectAndImagePoints(get_aruco_board(), ids_corners.corners, ids_corners.ids, boardPoints,
                                           imgPoints);
@@ -33,7 +33,7 @@ std::vector<BoardPointImagePointAssociation> obj_points_img_points_from_image(co
   return result;
 }
 
-std::optional<SE3> estimate_board_center_from_camera_from_image(const board_ids_and_corners ids_corners,
+std::optional<SE3> estimate_board_center_from_camera_from_image(const BoardIdsAndCorners ids_corners,
                                                                 const Calibration &calibration) {
   const cv::Mat camera_matrix = calibration.camera_matrix;
   const cv::Mat distortion_coefficients = calibration.distortion_coefficients;

--- a/vision/fiducial_detection_and_pose.cc
+++ b/vision/fiducial_detection_and_pose.cc
@@ -18,7 +18,7 @@ BoardIdsAndCorners get_ids_and_corners(const cv::Mat &input_image) {
   return result;
 }
 
-std::vector<BoardPointImagePointAssociation> obj_points_img_points_from_image(const BoardIdsAndCorners ids_corners) {
+std::vector<BoardPointImagePointAssociation> obj_points_img_points_from_image(const BoardIdsAndCorners& ids_corners) {
   cv::Mat boardPoints, imgPoints;
   cv::aruco::getBoardObjectAndImagePoints(get_aruco_board(), ids_corners.corners, ids_corners.ids, boardPoints,
                                           imgPoints);
@@ -33,7 +33,7 @@ std::vector<BoardPointImagePointAssociation> obj_points_img_points_from_image(co
   return result;
 }
 
-std::optional<SE3> estimate_board_center_from_camera_from_image(const BoardIdsAndCorners ids_corners,
+std::optional<SE3> estimate_board_center_from_camera_from_image(const BoardIdsAndCorners& ids_corners,
                                                                 const Calibration &calibration) {
   const cv::Mat camera_matrix = calibration.camera_matrix;
   const cv::Mat distortion_coefficients = calibration.distortion_coefficients;

--- a/vision/fiducial_detection_and_pose.cc
+++ b/vision/fiducial_detection_and_pose.cc
@@ -2,9 +2,9 @@
 #include <cassert>
 #include <cstdlib>
 
-namespace jet { 
+namespace jet {
 
-std::tuple<std::vector<int>, std::vector<std::vector<cv::Point2f>>> get_ids_and_corners(const cv::Mat &input_image) {
+board_ids_and_corners get_ids_and_corners(const cv::Mat &input_image) {
   std::vector<int> ids;
   std::vector<std::vector<cv::Point2f>> corners;
   const auto params = cv::aruco::DetectorParameters::create();
@@ -14,15 +14,14 @@ std::tuple<std::vector<int>, std::vector<std::vector<cv::Point2f>>> get_ids_and_
   // TODO isaac make aruco_dictionary parameter of this method to allow for
   // multiple unique boards
   cv::aruco::detectMarkers(input_image, get_aruco_dictionary(), corners, ids, params);
-  return std::make_tuple(ids, corners);
+  board_ids_and_corners result = {ids, corners};
+  return result;
 }
 
-std::vector<BoardPointImagePointAssociation> obj_points_img_points_from_image(const cv::Mat &input_image) {
-  const auto ids_corners = get_ids_and_corners(input_image);
-  const auto ids = std::get<0>(ids_corners);
-  const auto corners = std::get<1>(ids_corners);
+std::vector<BoardPointImagePointAssociation> obj_points_img_points_from_image(const board_ids_and_corners ids_corners) {
   cv::Mat boardPoints, imgPoints;
-  cv::aruco::getBoardObjectAndImagePoints(get_aruco_board(), corners, ids, boardPoints, imgPoints);
+  cv::aruco::getBoardObjectAndImagePoints(get_aruco_board(), ids_corners.corners, ids_corners.ids, boardPoints,
+                                          imgPoints);
   std::vector<BoardPointImagePointAssociation> result;
   for (int i = 0; i < boardPoints.rows; i++) {
     BoardPointImagePointAssociation association = {};
@@ -34,12 +33,8 @@ std::vector<BoardPointImagePointAssociation> obj_points_img_points_from_image(co
   return result;
 }
 
-std::optional<SE3> estimate_board_center_from_camera_from_image(const cv::Mat &input_image,
+std::optional<SE3> estimate_board_center_from_camera_from_image(const board_ids_and_corners ids_corners,
                                                                 const Calibration &calibration) {
-  const auto ids_corners = get_ids_and_corners(input_image);
-  const auto ids = std::get<0>(ids_corners);
-  const auto corners = std::get<1>(ids_corners);
-
   const cv::Mat camera_matrix = calibration.camera_matrix;
   const cv::Mat distortion_coefficients = calibration.distortion_coefficients;
 
@@ -48,9 +43,8 @@ std::optional<SE3> estimate_board_center_from_camera_from_image(const cv::Mat &i
   cv::Mat rvec;
   cv::Mat tvec;
 
-  const int num_fiducials_detected_on_board =
-      cv::aruco::estimatePoseBoard(corners, ids, get_aruco_board(),
-        camera_matrix, distortion_coefficients, rvec, tvec);
+  const int num_fiducials_detected_on_board = cv::aruco::estimatePoseBoard(
+      ids_corners.corners, ids_corners.ids, get_aruco_board(), camera_matrix, distortion_coefficients, rvec, tvec);
   (void)num_fiducials_detected_on_board;
 
   if (tvec.size().height > 0) {

--- a/vision/fiducial_detection_and_pose.hh
+++ b/vision/fiducial_detection_and_pose.hh
@@ -24,7 +24,7 @@ struct MarkerInWorld {
   int id;
 };
 
-struct board_ids_and_corners {
+struct BoardIdsAndCorners {
   std::vector<int> ids;
   std::vector<std::vector<cv::Point2f>> corners;
 };
@@ -72,13 +72,13 @@ struct BoardPointImagePointAssociation {
   SERIALIZABLE_STRUCTURE(BoardPointImagePointAssociation, point_board_space, point_image_space);
 };
 
-board_ids_and_corners get_ids_and_corners(const cv::Mat &input_image);
+BoardIdsAndCorners get_ids_and_corners(const cv::Mat &input_image);
 
 std::vector<MarkerInWorld> get_world_from_marker_centers(const cv::Mat& camera_image, const SE3& world_from_camera);
 
-std::optional<SE3> estimate_board_center_from_camera_from_image(board_ids_and_corners ids_corners, const Calibration& calibration);
+std::optional<SE3> estimate_board_center_from_camera_from_image(BoardIdsAndCorners ids_corners, const Calibration& calibration);
 
-std::vector<BoardPointImagePointAssociation> obj_points_img_points_from_image(board_ids_and_corners ids_corners);
+std::vector<BoardPointImagePointAssociation> obj_points_img_points_from_image(BoardIdsAndCorners ids_corners);
 
 constexpr float FIDUCIAL_WIDTH_METERS = 99.0 / 1000;
 constexpr float FIDUCIAL_GAP_WIDTH_METERS = 50.0 / 1000;

--- a/vision/fiducial_detection_and_pose.hh
+++ b/vision/fiducial_detection_and_pose.hh
@@ -24,6 +24,11 @@ struct MarkerInWorld {
   int id;
 };
 
+struct board_ids_and_corners {
+  std::vector<int> ids;
+  std::vector<std::vector<cv::Point2f>> corners;
+};
+
 template <int ROWS, int COLS>
 struct MatWrapper {
   using Mat = MatNd<ROWS, COLS>;
@@ -67,11 +72,13 @@ struct BoardPointImagePointAssociation {
   SERIALIZABLE_STRUCTURE(BoardPointImagePointAssociation, point_board_space, point_image_space);
 };
 
+board_ids_and_corners get_ids_and_corners(const cv::Mat &input_image);
+
 std::vector<MarkerInWorld> get_world_from_marker_centers(const cv::Mat& camera_image, const SE3& world_from_camera);
 
-std::optional<SE3> estimate_board_center_from_camera_from_image(const cv::Mat& input_image, const Calibration& calibration);
+std::optional<SE3> estimate_board_center_from_camera_from_image(board_ids_and_corners ids_corners, const Calibration& calibration);
 
-std::vector<BoardPointImagePointAssociation> obj_points_img_points_from_image(const cv::Mat& input_image);
+std::vector<BoardPointImagePointAssociation> obj_points_img_points_from_image(board_ids_and_corners ids_corners);
 
 constexpr float FIDUCIAL_WIDTH_METERS = 99.0 / 1000;
 constexpr float FIDUCIAL_GAP_WIDTH_METERS = 50.0 / 1000;

--- a/vision/fiducial_detection_and_pose.hh
+++ b/vision/fiducial_detection_and_pose.hh
@@ -76,9 +76,9 @@ BoardIdsAndCorners get_ids_and_corners(const cv::Mat &input_image);
 
 std::vector<MarkerInWorld> get_world_from_marker_centers(const cv::Mat& camera_image, const SE3& world_from_camera);
 
-std::optional<SE3> estimate_board_center_from_camera_from_image(BoardIdsAndCorners ids_corners, const Calibration& calibration);
+std::optional<SE3> estimate_board_center_from_camera_from_image(const BoardIdsAndCorners& ids_corners, const Calibration& calibration);
 
-std::vector<BoardPointImagePointAssociation> obj_points_img_points_from_image(BoardIdsAndCorners ids_corners);
+std::vector<BoardPointImagePointAssociation> obj_points_img_points_from_image(const BoardIdsAndCorners& ids_corners);
 
 constexpr float FIDUCIAL_WIDTH_METERS = 99.0 / 1000;
 constexpr float FIDUCIAL_GAP_WIDTH_METERS = 50.0 / 1000;

--- a/vision/fiducial_detection_balsaq.cc
+++ b/vision/fiducial_detection_balsaq.cc
@@ -34,10 +34,6 @@ void FidicualDetectionBq::loop() {
     const Calibration camera_calibration = camera_manager_.get_camera(image_message.camera_serial_number).calibration;
     const cv::Mat camera_frame = get_image_mat(image_message);
     const auto ids_corners = get_ids_and_corners(camera_frame);
-    std::cout << ids_corners.ids.size() << std::endl;
-    for (auto & element : ids_corners.ids) {
-      std::cout << "  " << element << std::endl;
-    }
     const std::optional<SE3> board_from_camera =
         estimate_board_center_from_camera_from_image(ids_corners, camera_calibration);
     if (board_from_camera) {
@@ -54,7 +50,6 @@ void FidicualDetectionBq::loop() {
       detection_message.timestamp = image_message.header.timestamp_ns;
 
       std::vector<BoardPointImagePointAssociation> board_point_assocs = obj_points_img_points_from_image(ids_corners);
-      std::cout << "associated pts" << board_point_assocs.size() << std::endl;
       detection_message.board_points_image_points = board_point_assocs;
 
       publisher_->publish(detection_message);


### PR DESCRIPTION
We were previously processing each image from scratch twice -- once to get the board pose and another time to get raw points.  Now we reuse the processed corner locations and IDs.