### PR TITLE
Update Camera Balsaq and Detection Frequencies 

### DIFF
--- a/camera/camera_balsaq.cc
+++ b/camera/camera_balsaq.cc
@@ -13,6 +13,8 @@
 namespace jet {
 
 void CameraBq::init(const Config& config) {
+  // 20Hz Update Rate
+  loop_delay_microseconds = 50000;
   camera_ = camera_manager_.get_camera(config["serial_number"].as<std::string>());
   std::cout << "Camera BQ: camera serial " << config["serial_number"].as<std::string>() << std::endl;
   cap_ = cv::VideoCapture(camera_.v4l_path);

--- a/camera/camera_balsaq.hh
+++ b/camera/camera_balsaq.hh
@@ -28,7 +28,6 @@ class CameraBq : public BalsaQ {
   void init(const Config& config);
   void loop();
   void shutdown();
-  const static uint loop_delay_microseconds = 50000;
 
  private:
   // Use this to convert a capture time to a wall time
@@ -38,7 +37,6 @@ class CameraBq : public BalsaQ {
   // The camera capture times are reported in millseconds from monotonic clock start
   // This function reconstructs a a reasonable approximation of the *vehicle* time
   // associated with that monotonic time
-  static const int CAMERA_FPS = 10;
   PublisherPtr publisher_;
   cv::VideoCapture cap_;
   Timestamp last_msg_recvd_timestamp_;

--- a/camera/camera_balsaq.hh
+++ b/camera/camera_balsaq.hh
@@ -28,6 +28,7 @@ class CameraBq : public BalsaQ {
   void init(const Config& config);
   void loop();
   void shutdown();
+  const static uint loop_delay_microseconds = 50000;
 
  private:
   // Use this to convert a capture time to a wall time

--- a/config/hoverjet/camera.yaml
+++ b/config/hoverjet/camera.yaml
@@ -1,13 +1,13 @@
 width_pixels: 640
 height_pixels: 480
 # Bold, I know!
-frames_per_second: 30
+frames_per_second: 20
 # Disable autofocus
 auto_focus: 0
 # Disables autoexposure...allegedly?
 auto_exposure: 1
 # Set a fixed exposure (The minimum)
-webcam_exposure: 3
+exposure: 3
 
 # Calling our shots: The camera we expect to be running
 serial_number: 5CFD076E

--- a/embedded/imu_driver/imu_balsaq.cc
+++ b/embedded/imu_driver/imu_balsaq.cc
@@ -12,6 +12,8 @@ namespace jet {
 namespace embedded {
 
 void ImuBq::init(const Config& config) {
+  // Every 10 milliseconds
+  loop_delay_microseconds = 10000;
   const std::string bus = config["bus"].as<std::string>();
 
   imu_drivers_.reserve(config["imus"].size());
@@ -52,6 +54,7 @@ void ImuBq::init(const Config& config) {
       error_msg << "GUID Mismatch, expected: "<< expected_imu_guid << " got: " << actual_guid << std::endl;;
       throw std::runtime_error(error_msg.str());
     }
+
   }
 
   if (all_go) {

--- a/embedded/imu_driver/imu_balsaq.hh
+++ b/embedded/imu_driver/imu_balsaq.hh
@@ -27,9 +27,6 @@ class ImuBq : public BalsaQ {
   void loop();
   void shutdown();
 
-  // Every 10 milliseconds
-  const static uint loop_delay_microseconds = 10000;
-
  private:
   std::vector<ManagedDriver> imu_drivers_;
 };

--- a/vision/fiducial_detection_balsaq.cc
+++ b/vision/fiducial_detection_balsaq.cc
@@ -13,6 +13,8 @@
 namespace jet {
 
 void FiducialDetectionBq::init(const Config& config) {
+  // 20Hz Update Rate
+  loop_delay_microseconds = 50000;
   subscriber_ = make_subscriber("camera_image_channel");
   publisher_ = make_publisher("fiducial_detection_channel");
 }

--- a/vision/fiducial_detection_balsaq.hh
+++ b/vision/fiducial_detection_balsaq.hh
@@ -22,7 +22,6 @@ class FiducialDetectionBq : public BalsaQ {
   void init(const Config& config) override;
   void loop() override;
   void shutdown() override;
-  const static uint loop_delay_microseconds = 50000;
 
  private:
   PublisherPtr publisher_;

--- a/vision/fiducial_detection_balsaq.hh
+++ b/vision/fiducial_detection_balsaq.hh
@@ -22,6 +22,7 @@ class FiducialDetectionBq : public BalsaQ {
   void init(const Config& config) override;
   void loop() override;
   void shutdown() override;
+  const static uint loop_delay_microseconds = 50000;
 
  private:
   PublisherPtr publisher_;


### PR DESCRIPTION
Changing the camera pipeline to work at 20Hz, since we're eating up compute by processing 30fps images and only using 10Hz in the fiducial detection.  