### PR TITLE
Fixing message deserialization as base type bug

### DIFF
--- a/infrastructure/comms/schemas/message.hh
+++ b/infrastructure/comms/schemas/message.hh
@@ -4,10 +4,48 @@
 
 namespace jet {
 
+namespace {
+const uint16_t MESSAGE_SERIZLIED_SIZE_BYTES = 26;
+}
+
 struct Message {
   MessageHeader header;
 
-  MESSAGE(Message, header);
+  // Temporary fix to a deserialization problem:
+  // Message requires a custom deserializer to support deserialization of derived types as base
+  // message types. NOP's wire format is as follows:
+  // [type specifier byte] [number of fields to follow (up to four bytes)] [fields ...]
+  // For a struct, the first byte will always be 0xb9. As long as we have fewer than 128 fields, the second byte
+  // indicates the number of fields to deserialize.
+  // A serialized derived message's second byte will represent the number of fields in the derived
+  // message.
+  // If you try to deserialize a derived message as a base Message type, NOP will fail to
+  // deserialize properly because the number of fields in the Message struct won't match the number
+  // of fields indicated in the second byte of the serialized derived message.
+  //
+  // Quick, temporary solution: When deserializing a message as type <Message>, force the number of
+  // fields indicated in the serialized message to 1 so that NOP is tricked into interpreting the serialized
+  // message as a <Message> type.
+  virtual void deserialize(const std::string& data) {
+    if (data[1] != 0x1) {
+      std::string data_copy = data.substr(0, MESSAGE_SERIZLIED_SIZE_BYTES);
+      data_copy[1] = 0x1;
+      nop::Deserializer<nop::StreamReader<std::stringstream>> deserializer{data_copy};
+      deserializer.Read(this);
+    } else {
+      nop::Deserializer<nop::StreamReader<std::stringstream>> deserializer{data};
+      deserializer.Read(this);
+    }
+  }
+
+  virtual void serialize(std::string& data) {
+    using Writer = nop::StreamWriter<std::stringstream>;
+    nop::Serializer<Writer> serializer;
+    serializer.Write(*this);
+    data = serializer.writer().take().str();
+  }
+
+  NOP_STRUCTURE(Message, header);
 };
 
 }  //  namespace jet


### PR DESCRIPTION
A problem was found with message deserialization: If you try to deserialize a derived message type as a base Message to get just header information, deserialization sometimes fails. My initial tests of polymorphic deserialization passed, but it appears that the tests only passed coincidentally.

NOP serialized structures store the number of fields to expect in the second byte of the serialized data. Message only has one field: header. When you try to deserialize another type (such as ImuMessage) as a base Message, NOP fails to deserialize silently, since Message has only one field, but the serialized message it was provided indicates a different number of fields (12 fields, in the case of ImuMessage).

The quick and simple fix is to override the deserializer for Message with a new deserializer that forces the number of fields indicated in the serialized data to be 0x1, no matter what the serialized data actually indicates. This solution has been tested to work with an assortment of types.

Note: This is a temporary solution. Is has the following problems:
1. It solves polymorphic deserialization for structs that derive from Message, but doesn't fix the problem for structures that derive from any other serializable structure. This isn't a big deal right now, since the only structure we derive from today is Message.
2. If we have more than 128 fields in a derived message, this will break, since NOP is allowed to use up to four bytes to indicate the number of expected fields, not just one.
