### PR TITLE
Add "--qemu-arm" flag to "jet build" and "jet run"

### DIFF
--- a/infrastructure/scripts/environment_bootstrap.sh
+++ b/infrastructure/scripts/environment_bootstrap.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+# Set up proper error handling and disallow unset arguments
+set -o errexit -o errtrace -o pipefail -o nounset
+
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 
 # Add the hover-jet repository's "scripts" directory to path for new shells

--- a/infrastructure/scripts/jet
+++ b/infrastructure/scripts/jet
@@ -1,10 +1,15 @@
 #!/bin/bash
 
+
+# Set up proper error handling and disallow unset arguments
+set -o errexit -o errtrace -o pipefail -o nounset
+
+
 function help () {
 cat <<-END
 Usage: jet COMMAND
 
-Builds a new jet Docker image for your host's architecture.
+Acts as a command line entry point to the project's scripts.
 
 -h| --help           Show this message
 
@@ -17,7 +22,7 @@ broker               Configure the IPC Broker on this host
 END
 }
 
-while [ -n "$1" ]; do
+while [[ $# -gt 0 ]]; do
     case "$1" in
         -h | --help)
             help

--- a/infrastructure/scripts/jet_broker.sh
+++ b/infrastructure/scripts/jet_broker.sh
@@ -1,10 +1,13 @@
 #!/bin/bash
 
+# Set up proper error handling and disallow unset arguments
+set -o errexit -o errtrace -o pipefail -o nounset
+
 source jet_functions.sh
 
 function help () {
 cat <<-END
-Usage: jet build
+Usage: jet broker
 
 Starts up a new IPC Broker container. If one is already running, does nothing.
 
@@ -19,7 +22,7 @@ FORCE_RESTART=0
 IPC_BROKER_IS_RUNNING=0
 START=1
 
-while test $# -gt 0; do
+while [[ $# -gt 0 ]]; do
         case "$1" in
                 -h|--help)
                         help

--- a/infrastructure/scripts/jet_deploy.sh
+++ b/infrastructure/scripts/jet_deploy.sh
@@ -1,3 +1,6 @@
 #!/bin/bash
 
+# Set up proper error handling and disallow unset arguments
+set -o errexit -o errtrace -o pipefail -o nounset
+
 echo "jet deploy not yet implemented."

--- a/infrastructure/scripts/jet_functions.sh
+++ b/infrastructure/scripts/jet_functions.sh
@@ -1,14 +1,70 @@
 #!/bin/bash
 
+# Set up proper error handling and disallow unset arguments
+set -o errexit -o errtrace -o pipefail -o nounset
+
+ENABLE_QEMU_ARM=0
+
+_echo_err() {
+
+    # Send messages to the console on stderr since stdout is used for returns
+    echo "$@" >&2
+}
+
+get_qemu_arm_static_path() {
+
+    if [[ "$ENABLE_QEMU_ARM" == 1 ]]; then
+
+        # Detect if the qemu-arm-static binary is installed and return the path if so
+        echo "$(ls /usr/bin/qemu-arm-static 2> /dev/null)"
+    fi
+}
+
+_get_architecture() {
+    local cpu_info="$(lscpu | grep '^Architecture:')"
+    local cpu_architecture=""
+
+    if [[ "$cpu_info" =~ "x86_64" ]]; then
+        cpu_architecture="x86_64"
+    elif [[ "$cpu_info" =~ "arm" ]]; then
+        cpu_architecture="arm"
+    fi
+
+    echo "$cpu_architecture"
+}
+
+_map_architecture_to_image() {
+    local cpu_architecture="$1"
+    local image_name=""
+
+    if [[ "$cpu_architecture" == "x86_64" ]]; then
+        image_name="hoverjet/jet"
+    elif [[ "$cpu_architecture" == "arm" ]]; then
+        image_name="hoverjet/jet-arm"
+    fi
+
+    echo "$image_name"
+}
+
+_qemu_arm_image() {
+    if [[ "$(_get_architecture)" != "x86_64" ]]; then
+        _echo_err "Using --qemu-arm is only intended for x86_64 platforms"
+        exit 1
+    elif [[ -z "$(get_qemu_arm_static_path)" ]]; then
+        _echo_err "You need to install the qemu-user-static package first"
+        _echo_err ""
+        _echo_err "Run the following command to do so:"
+        _echo_err "sudo apt-get install qemu-user-static"
+        exit 1
+    fi
+
+    echo "hoverjet/jet-arm"
+}
+
 get_image_name() {
-    # The bash lines below are left intentionally commented
-    # They will be returned when it is time to return to the latest Docker image
-    CPU_INFO=$(lscpu)
-    if [[ $(echo $CPU_INFO | grep "Architecture:") =~ "x86_64" ]]; then
-        IMAGE_NAME="hoverjet/jet"
+    if [[ "$ENABLE_QEMU_ARM" == 1 ]]; then
+        _qemu_arm_image
+    else
+        _map_architecture_to_image "$(_get_architecture)"
     fi
-    if [[ $(echo $CPU_INFO | grep "Architecture:") =~ "arm" ]]; then
-        IMAGE_NAME="hoverjet/jet-arm"
-    fi
-    echo "$IMAGE_NAME"
 }

--- a/infrastructure/scripts/jet_image.sh
+++ b/infrastructure/scripts/jet_image.sh
@@ -1,25 +1,30 @@
 #!/bin/bash
 
+# Set up proper error handling and disallow unset arguments
+set -o errexit -o errtrace -o pipefail -o nounset
+
 source jet_functions.sh
 
 function help () {
 cat <<-END
-Usage: jet build
+Usage: jet image
 
 Builds a new jet Docker image for your host's architecture.
 
 -h| --help           Show this message
-pull| --pull         Pull the most recent version of the hoverjet/jet Docker image
 -p| --push           Push this image to Docker Hub on build completion
+--pull               Pull the most recent version of the hoverjet/jet Docker image
 --latest             Tag the image as "latest" on build completion
 --no-cache           Run a clean build of the image, reperforming every cached step
 END
 }
 
+PULL=0
 PUSH=0
 LATEST=0
+NO_CACHE=""
 
-while test $# -gt 0; do
+while [[ $# -gt 0 ]]; do
         case "$1" in
                 -h|--help)
                         help


### PR DESCRIPTION
Building on the ODROID appears to take longer than the average human
life span, so this flag enables using QMEU User Emulation to run the
build (and potentially the whole stack) in the `arm` container on an
`x86_64` machine.

If this flag is used, `get_image_name` will verify that the
`qemu-user-static` binary is present on the system and that the user is
indeed on an `x86_64` platform. If these checks pass, the
`hoverjet/jet-arm` image will be fetched and the
`/usr/bin/qemu-user-static` binary will be added as a bind mount to the
`docker run` commands used in the `jet_build.sh` and `jet_run.sh`
scripts. From there on, everything should be seamless.

Preliminary testing has just consisted of building the full project,
which seems to take very close to 96 minutes regardless of the number of
jobs used (valused of `3`, `4`, and `7` were tested). This implies that
the build does not parallelize well and that throwing more cores at the
problem will not help much, but it should still be tested. The machine
that ran this testing had `2` cores and `4` threads.

Running the software stack both within a container running in this mode
and on the jet itself (the build repository would be copied over) should
also be tested prior to landing.