### PR TITLE
Feature/log reader reads all log files

### DIFF
--- a/infrastructure/logging/log_reader.cc
+++ b/infrastructure/logging/log_reader.cc
@@ -16,8 +16,7 @@ LogReader::LogReader(const std::string& log_path, const std::vector<std::string>
     throw std::runtime_error("Couldn't open metadata file for log: " + log_path);
   }
 
-  if (channel_names.empty())
-  {
+  if (channel_names.empty()) {
     for (auto& channel_name : channels_in_log_) {
       ChannelState channel;
       if (!get_logfile(channel, channel_name)) {
@@ -29,8 +28,7 @@ LogReader::LogReader(const std::string& log_path, const std::vector<std::string>
   else {
     for (auto& channel_name : channel_names) {
       auto channel_it = std::find(channels_in_log_.begin(), channels_in_log_.end(), channel_name);
-      if (channel_it != channels_in_log_.end())
-      {
+      if (channel_it != channels_in_log_.end()) {
         ChannelState channel;
         if (!get_logfile(channel, channel_name)) {
           throw std::runtime_error("Couldn't open file for " + channel_name);
@@ -44,10 +42,8 @@ LogReader::LogReader(const std::string& log_path, const std::vector<std::string>
   }
 }
 
-
 LogReader::~LogReader() {
-  for (auto& channel : channels_)
-  {
+  for (auto& channel : channels_) {
     channel.second.current_file.close();
   }
 }
@@ -69,13 +65,13 @@ bool LogReader::try_read_next_message(ChannelState& channel, Message& message) {
   file.read((char*) &channel_id, sizeof(uint32_t));
   file.read((char*) &message_length, sizeof(uint32_t));
 
-  if (file.eof()) {
+  if (!file.good()) {
     return false;
   }
 
   std::string message_data(message_length, ' ');
   file.read(&message_data[0], message_length);
-  if (!file) {
+  if (!file.good()) {
     return false;      
   }
   message.deserialize(message_data);
@@ -84,20 +80,20 @@ bool LogReader::try_read_next_message(ChannelState& channel, Message& message) {
 
 bool LogReader::read_next_message(const std::string& channel_name, Message& message) {
   auto channel_it = channels_.find(channel_name);
-  if (channel_it != channels_.end()) {
-    // Try to read a message from the current log file
-    if (try_read_next_message(channel_it->second, message)) {
-      return true;
-    }
-    // Otherwise get the next logfile if it exists
-    channel_it->second.current_file_number++;
-    if (!get_logfile(channel_it->second, channel_name)) {
-      return false;
-    }
-    // If we can't read from next logfile then give up
-    return try_read_next_message(channel_it->second, message);
+  if (channel_it == channels_.end()) {
+    return false;
   }
-  return false;
+  // Try to read a message from the current log file
+  if (try_read_next_message(channel_it->second, message)) {
+    return true;
+  }
+  // Otherwise get the next logfile if it exists
+  channel_it->second.current_file_number++;
+  if (!get_logfile(channel_it->second, channel_name)) {
+    return false;
+  }
+  // If we can't read from next logfile then give up
+  return try_read_next_message(channel_it->second, message);
 }
 
 bool LogReader::try_read_next_message_raw(ChannelState& channel, std::string& message_data) {
@@ -106,40 +102,44 @@ bool LogReader::try_read_next_message_raw(ChannelState& channel, std::string& me
   uint32_t message_length;
   file.read((char*) &channel_id, sizeof(uint32_t));
   file.read((char*) &message_length, sizeof(uint32_t));
+
+  if (!file.good()) {
+    return false;
+  }
+
   message_data.resize(message_length, ' ');
   file.read(&message_data[0], message_length);
+  
   return file.good();
 }
 
 bool LogReader::read_next_message_raw(const std::string& channel_name, std::string& message_data) {
   auto channel_it = channels_.find(channel_name);
-  if (channel_it != channels_.end()) {
-    // Try to read a message from the current log file
-    if (try_read_next_message_raw(channel_it->second, message_data)) {
-      return true;
-    }
-    // Otherwise get the next log file if it exists
-    channel_it->second.current_file_number++;
-    if (!get_logfile(channel_it->second, channel_name)) {
-      return false;
-    }
-    // If we can't read from teh next logfile, then give up
-    return try_read_next_message_raw(channel_it->second, message_data);
+  if (channel_it == channels_.end()) {
+    return false;
   }
-  return false;
+  // Try to read a message from the current log file
+  if (try_read_next_message_raw(channel_it->second, message_data)) {
+    return true;
+  }
+  // Otherwise get the next log file if it exists
+  channel_it->second.current_file_number++;
+  if (!get_logfile(channel_it->second, channel_name)) {
+    return false;
+  }
+  // If we can't read from teh next logfile, then give up
+  return try_read_next_message_raw(channel_it->second, message_data);
 }
 
 bool LogReader::read_metadata(const std::string& log_path, std::vector<std::string>& channel_names) {
   const std::string metadata_path = log_path + "/metadata.txt";
   std::ifstream metadata_file;
-  if (!open_file(metadata_path, metadata_file))
-  {
+  if (!open_file(metadata_path, metadata_file)) {
     return false;
   }
 
   std::string line;
-  while (std::getline(metadata_file, line))
-  {
+  while (std::getline(metadata_file, line)) {
     channels_in_log_.emplace_back(line);
   }
   metadata_file.close();

--- a/infrastructure/logging/log_reader.cc
+++ b/infrastructure/logging/log_reader.cc
@@ -109,7 +109,7 @@ bool LogReader::try_read_next_message_raw(ChannelState& channel, std::string& me
 
   message_data.resize(message_length, ' ');
   file.read(&message_data[0], message_length);
-  
+
   return file.good();
 }
 
@@ -127,7 +127,7 @@ bool LogReader::read_next_message_raw(const std::string& channel_name, std::stri
   if (!get_logfile(channel_it->second, channel_name)) {
     return false;
   }
-  // If we can't read from teh next logfile, then give up
+  // If we can't read from the next logfile, then give up
   return try_read_next_message_raw(channel_it->second, message_data);
 }
 

--- a/infrastructure/logging/log_reader.hh
+++ b/infrastructure/logging/log_reader.hh
@@ -38,8 +38,10 @@ class LogReader {
 
  private:
   bool open_file(const std::string& file_path, std::ifstream& file);
+  bool try_read_next_message(ChannelState& channel, Message& message);
+  bool try_read_next_message_raw(ChannelState& channel, std::string& message_data);
+  bool get_logfile(ChannelState& channel, std::string channel_name);
   bool read_metadata(const std::string& log_path, std::vector<std::string>& channel_names);
-
   std::string log_path_;
   std::unordered_map<std::string, ChannelState> channels_;
   std::vector<std::string> channels_in_log_;


### PR DESCRIPTION
Fixes issue where camera images seem to cut out earlier than all other logged data.  Turns out we aren't reading all of the log!