### PR TITLE
Replace environment bootstrap with direnv

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,2 +1,4 @@
+# direnv's .envrc works with bash-like export and unset, etc.
+# but see `man direnv-stdlib` or <https://direnv.net/man/direnv-stdlib.1.html> for built-in functions
 PATH_add infrastructure/scripts
 

--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,2 @@
+PATH_add infrastructure/scripts
+

--- a/readme.md
+++ b/readme.md
@@ -39,6 +39,10 @@ git pull --rebase origin master
 ./infrastructure/scripts/environment_bootstrap.sh
 ```
 
+### Using `direnv`
+
+1. Set up `direnv` ([install the binary/package](https://direnv.net/docs/installation.html) + [hook into your shell](https://direnv.net/docs/hook.html)).
+2. Run `direnv allow` inside your repo. `direnv` should complain about being blocked until you do this.
 
 # How to get the Docker image
 


### PR DESCRIPTION
Use [`direnv`](https://direnv.net/) to initialize environment variables - this prevents the need to bake the `infrastructure/scripts` dir into your `~/.bashrc` directly, by automatically loading/unloading when you enter/leave your working copy directory