### PR TITLE
[Dev] Fix visibility of OpenCV headers

### DIFF
--- a/infrastructure/scripts/docker/Dockerfile
+++ b/infrastructure/scripts/docker/Dockerfile
@@ -38,6 +38,7 @@ RUN apt update --fix-missing
 RUN cd /; apt install libgtk2.0-dev libavcodec-dev libavformat-dev libswscale-dev -y
 RUN git clone https://github.com/opencv/opencv_contrib.git --depth=1
 RUN cd opencv_contrib; CONTRIB_PATH=$PWD; git reset --hard a17185c6dc7aa554591ad1be38923232472f8001; cd ..; git clone https://github.com/opencv/opencv.git --depth=1; cd opencv; git reset --hard e2dbf054ac5c54bd328f648d9d6146c09dfd5484; mkdir build; cd build; cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/usr/local -DOPENCV_EXTRA_MODULES_PATH=$CONTRIB_PATH/modules ..; make -j7; make install
+RUN ln -s /usr/local/include/opencv4/opencv2/ /usr/local/include/
 RUN rm -rf opencv
 RUN rm -rf opencv_contrib
 RUN ldconfig -p


### PR DESCRIPTION
**Description**
PR  adds a step to the Dockerfile that exposes the `opencv2` directory in `/usr/local/include`. Current versions of OpenCV will tuck this folder behind the `opencv4` folder making any header inclusions a bit awkward.

**Test Plan**
Generated a few Docker images with this - all looks fine n' dandy